### PR TITLE
Add unit tests and remove unused ResponseInterface imports

### DIFF
--- a/src/DTO/Response/Attribute/AttributeCollectionResponse.php
+++ b/src/DTO/Response/Attribute/AttributeCollectionResponse.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Apiera\Sdk\DTO\Response\Attribute;
 
 use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;

--- a/src/DTO/Response/Attribute/AttributeResponse.php
+++ b/src/DTO/Response/Attribute/AttributeResponse.php
@@ -4,7 +4,6 @@ namespace Apiera\Sdk\DTO\Response\Attribute;
 
 use Apiera\Sdk\DTO\Response\AbstractResponse;
 use Apiera\Sdk\Enum\LdType;
-use Apiera\Sdk\Interface\DTO\ResponseInterface;
 use DateTimeInterface;
 use Symfony\Component\Uid\Uuid;
 
@@ -13,7 +12,7 @@ use Symfony\Component\Uid\Uuid;
  * @package Apiera\Sdk\DTO\Response\Attribute
  * @since 0.2.0
  */
-final readonly class AttributeResponse extends AbstractResponse implements ResponseInterface
+final readonly class AttributeResponse extends AbstractResponse
 {
     /**
      * @param string $id

--- a/src/DTO/Response/Category/CategoryResponse.php
+++ b/src/DTO/Response/Category/CategoryResponse.php
@@ -6,7 +6,6 @@ namespace Apiera\Sdk\DTO\Response\Category;
 
 use Apiera\Sdk\DTO\Response\AbstractResponse;
 use Apiera\Sdk\Enum\LdType;
-use Apiera\Sdk\Interface\DTO\ResponseInterface;
 use DateTimeInterface;
 use Symfony\Component\Uid\Uuid;
 

--- a/src/DTO/Response/Category/CategoryResponse.php
+++ b/src/DTO/Response/Category/CategoryResponse.php
@@ -15,7 +15,7 @@ use Symfony\Component\Uid\Uuid;
  * @package Apiera\Sdk\DTO\Response\Category
  * @since 0.1.0
  */
-final readonly class CategoryResponse extends AbstractResponse implements ResponseInterface
+final readonly class CategoryResponse extends AbstractResponse
 {
     /**
      * @param string $id

--- a/tests/Unit/DTO/Response/Attribute/AttributeCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Attribute/AttributeCollectionResponseTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Unit\DTO\Response\Attribute;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+use Apiera\Sdk\DTO\Response\Attribute\AttributeCollectionResponse;
+use Apiera\Sdk\DTO\Response\Attribute\AttributeResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDCollectionInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+class AttributeCollectionResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new AttributeCollectionResponse(
+            context: '',
+            id: '',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertInstanceOf(AttributeCollectionResponse::class, $response);
+        $this->assertInstanceOf(AbstractCollectionResponse::class, $response);
+        $this->assertInstanceOf(JsonLDCollectionInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(AttributeCollectionResponse::class);
+
+        $this->assertTrue($reflection->isFinal(), 'Class should be final');
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $attributeResponse = new AttributeResponse(
+            id: '/api/v1/attributes/123',
+            type: LdType::Attribute,
+            uuid: Uuid::v4(),
+            createdAt: new DateTimeImmutable(),
+            updatedAt: new DateTimeImmutable(),
+            name: 'Color',
+            store: '/api/v1/stores/321'
+        );
+
+        $response = new AttributeCollectionResponse(
+            context: '/api/v1/contexts/Attribute',
+            id: '/api/v1/attributes',
+            type: LdType::Collection,
+            members: [$attributeResponse],
+            totalItems: 1,
+            view: '/api/v1/attributes?page=1',
+            firstPage: '/api/v1/attributes?page=1',
+            lastPage: '/api/v1/attributes?page=1',
+            nextPage: null,
+            previousPage: null
+        );
+
+        $this->assertEquals('/api/v1/contexts/Attribute', $response->getLdContext());
+        $this->assertEquals('/api/v1/attributes', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertCount(1, $response->getMembers());
+        $this->assertInstanceOf(AttributeResponse::class, $response->getMembers()[0]);
+        $this->assertEquals(1, $response->getTotalItems());
+        $this->assertEquals('/api/v1/attributes?page=1', $response->getView());
+        $this->assertEquals('/api/v1/attributes?page=1', $response->getFirstPage());
+        $this->assertEquals('/api/v1/attributes?page=1', $response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $response = new AttributeCollectionResponse(
+            context: '/api/v1/contexts/Attribute',
+            id: '/api/v1/attributes',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertEquals('/api/v1/contexts/Attribute', $response->getLdContext());
+        $this->assertEquals('/api/v1/attributes', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertEmpty($response->getMembers());
+        $this->assertEquals(0, $response->getTotalItems());
+        $this->assertNull($response->getView());
+        $this->assertNull($response->getFirstPage());
+        $this->assertNull($response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+}

--- a/tests/Unit/DTO/Response/Attribute/AttributeResponseTest.php
+++ b/tests/Unit/DTO/Response/Attribute/AttributeResponseTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Unit\DTO\Response\Attribute;
+
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\DTO\Response\Attribute\AttributeResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDInterface;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+class AttributeResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new AttributeResponse(
+            id: '',
+            type: LdType::Attribute,
+            uuid: Uuid::v4(),
+            createdAt: new DateTimeImmutable(),
+            updatedAt: new DateTimeImmutable(),
+            name: '',
+            store: ''
+        );
+
+        $this->assertInstanceOf(AttributeResponse::class, $response);
+        $this->assertInstanceOf(AbstractResponse::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(JsonLDInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(AttributeResponse::class);
+
+        $this->assertTrue($reflection->isFinal(), 'Class should be final');
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testPropertiesAreReadonly(): void
+    {
+        $reflection = new ReflectionClass(AttributeResponse::class);
+        $properties = $reflection->getProperties();
+
+        foreach ($properties as $property) {
+            $this->assertTrue($property->isReadonly(), sprintf('Property %s should be readonly', $property->getName()));
+        }
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $response = new AttributeResponse(
+            id: '/api/v1/attributes/123',
+            type: LdType::Attribute,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Color',
+            store: '/api/v1/stores/321'
+        );
+
+        $this->assertEquals('/api/v1/attributes/123', $response->getLdId());
+        $this->assertEquals(LdType::Attribute, $response->getLdType());
+        $this->assertTrue(Uuid::isValid($response->getUuid()->toRfc4122()));
+        $this->assertEquals('bfd2639c-7793-426a-a413-ea262e582208', $response->getUuid()->toRfc4122());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getCreatedAt());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getUpdatedAt());
+        $this->assertEquals('Color', $response->getName());
+        $this->assertEquals('/api/v1/stores/321', $response->getStore());
+    }
+}

--- a/tests/Unit/DTO/Response/Category/CategoryCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Category/CategoryCollectionResponseTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Unit\DTO\Response\Category;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+use Apiera\Sdk\DTO\Response\Category\CategoryCollectionResponse;
+use Apiera\Sdk\DTO\Response\Category\CategoryResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDCollectionInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+class CategoryCollectionResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new CategoryCollectionResponse(
+            context: '',
+            id: '',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertInstanceOf(CategoryCollectionResponse::class, $response);
+        $this->assertInstanceOf(AbstractCollectionResponse::class, $response);
+        $this->assertInstanceOf(JsonLDCollectionInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(CategoryCollectionResponse::class);
+
+        $this->assertTrue($reflection->isFinal(), 'Class should be final');
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $categoryResponse = new CategoryResponse(
+            id: '/api/v1/categories/123',
+            type: LdType::Category,
+            uuid: Uuid::v4(),
+            createdAt: new DateTimeImmutable(),
+            updatedAt: new DateTimeImmutable(),
+            name: 'Electronics',
+            store: '/api/v1/stores/321'
+        );
+
+        $response = new CategoryCollectionResponse(
+            context: '/api/v1/contexts/Category',
+            id: '/api/v1/categories',
+            type: LdType::Collection,
+            members: [$categoryResponse],
+            totalItems: 1,
+            view: '/api/v1/categories?page=1',
+            firstPage: '/api/v1/categories?page=1',
+            lastPage: '/api/v1/categories?page=1',
+            nextPage: null,
+            previousPage: null
+        );
+
+        $this->assertEquals('/api/v1/contexts/Category', $response->getLdContext());
+        $this->assertEquals('/api/v1/categories', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertCount(1, $response->getMembers());
+        $this->assertInstanceOf(CategoryResponse::class, $response->getMembers()[0]);
+        $this->assertEquals(1, $response->getTotalItems());
+        $this->assertEquals('/api/v1/categories?page=1', $response->getView());
+        $this->assertEquals('/api/v1/categories?page=1', $response->getFirstPage());
+        $this->assertEquals('/api/v1/categories?page=1', $response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $response = new CategoryCollectionResponse(
+            context: '/api/v1/contexts/Category',
+            id: '/api/v1/categories',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertEquals('/api/v1/contexts/Category', $response->getLdContext());
+        $this->assertEquals('/api/v1/categories', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertEmpty($response->getMembers());
+        $this->assertEquals(0, $response->getTotalItems());
+        $this->assertNull($response->getView());
+        $this->assertNull($response->getFirstPage());
+        $this->assertNull($response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+}

--- a/tests/Unit/DTO/Response/Category/CategoryResponseTest.php
+++ b/tests/Unit/DTO/Response/Category/CategoryResponseTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\DTO\Response\Category;
+
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\DTO\Response\Category\CategoryResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDInterface;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+class CategoryResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new CategoryResponse(
+            id: '',
+            type: LdType::Category,
+            uuid: Uuid::v4(),
+            createdAt: new DateTimeImmutable(),
+            updatedAt: new DateTimeImmutable(),
+            name: '',
+            store: ''
+        );
+
+        $this->assertInstanceOf(CategoryResponse::class, $response);
+        $this->assertInstanceOf(AbstractResponse::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(JsonLDInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(CategoryResponse::class);
+
+        $this->assertTrue($reflection->isFinal(), 'Class should be final');
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testPropertiesAreReadonly(): void
+    {
+        $reflection = new ReflectionClass(CategoryResponse::class);
+        $properties = $reflection->getProperties();
+
+        foreach ($properties as $property) {
+            $this->assertTrue($property->isReadonly(), sprintf('Property %s should be readonly', $property->getName()));
+        }
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $response = new CategoryResponse(
+            id: '/api/v1/categories/123',
+            type: LdType::Category,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Electronics',
+            store: '/api/v1/stores/321',
+            description: 'A category for electronics.',
+            parent: '/api/v1/stores/321/categories/456',
+            image: '/api/v1/files/789',
+        );
+
+        $this->assertEquals('/api/v1/categories/123', $response->getLdId());
+        $this->assertEquals(LdType::Category, $response->getLdType());
+        $this->assertTrue(Uuid::isValid($response->getUuid()->toRfc4122()));
+        $this->assertEquals('bfd2639c-7793-426a-a413-ea262e582208', $response->getUuid()->toRfc4122());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getCreatedAt());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getUpdatedAt());
+        $this->assertEquals('Electronics', $response->getName());
+        $this->assertEquals('/api/v1/stores/321', $response->getStore());
+        $this->assertEquals('A category for electronics.', $response->getDescription());
+        $this->assertEquals('/api/v1/stores/321/categories/456', $response->getParent());
+        $this->assertEquals('/api/v1/files/789', $response->getImage());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $response = new CategoryResponse(
+            id: '/api/v1/categories/123',
+            type: LdType::Category,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Electronics',
+            store: '/api/v1/stores/321'
+        );
+
+        $this->assertEquals('/api/v1/categories/123', $response->getLdId());
+        $this->assertEquals(LdType::Category, $response->getLdType());
+        $this->assertTrue(Uuid::isValid($response->getUuid()->toRfc4122()));
+        $this->assertEquals('bfd2639c-7793-426a-a413-ea262e582208', $response->getUuid()->toRfc4122());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getCreatedAt());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getUpdatedAt());
+        $this->assertEquals('Electronics', $response->getName());
+        $this->assertEquals('/api/v1/stores/321', $response->getStore());
+        $this->assertNull($response->getDescription());
+        $this->assertNull($response->getParent());
+        $this->assertNull($response->getImage());
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces the following changes:

- Added unit tests for `CategoryCollectionResponse` and `AttributeCollectionResponse` to ensure proper functionality, covering constructor behavior, inheritance, and property validation under various scenarios.
- Removed unused `ResponseInterface` imports from `CategoryResponse` and `AttributeResponse`, reducing code clutter and maintaining clean coding practices.
- Removed unnecessary implementation of `ResponseInterface` in `CategoryResponse` and `AttributeResponse`.
- Added comprehensive unit tests for the `AttributeResponse` and `CategoryResponse` classes to verify correctness, including type checks, immutability, and method behavior.