### PR TITLE
Refactor and test data mappers for category and attribute

### DIFF
--- a/src/DataMapper/AttributeDataMapper.php
+++ b/src/DataMapper/AttributeDataMapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Apiera\Sdk\DataMapper;
 
 use Apiera\Sdk\DTO\Request\Attribute\AttributeRequest;
@@ -9,19 +11,19 @@ use Apiera\Sdk\Enum\LdType;
 use Apiera\Sdk\Exception\ClientException;
 use Apiera\Sdk\Interface\ClientExceptionInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
-use Apiera\Sdk\Interface\DTO\JsonLDInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
 use Apiera\Sdk\Interface\DTO\ResponseInterface;
-use DateMalformedStringException;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
+use Throwable;
+use ValueError;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @package Apiera\Sdk\DataMapper
  * @since 0.2.0
  */
-class AttributeDataMapper implements DataMapperInterface
+final class AttributeDataMapper implements DataMapperInterface
 {
     /**
      * @param array<string, mixed> $responseData
@@ -40,37 +42,43 @@ class AttributeDataMapper implements DataMapperInterface
                 name: $responseData['name'],
                 store: $responseData['store'],
             );
-        } catch (DateMalformedStringException $exception) {
-            throw new ClientException($exception->getMessage(), $exception->getCode(), $exception);
+        } catch (Throwable $exception) {
+            throw new ClientException(
+                message: 'Failed to map response data: ' . $exception->getMessage(),
+                previous: $exception
+            );
         }
     }
 
     /**
-     * @param array<string, mixed> $collectionData
+     * @param array<string, mixed> $collectionResponseData
      * @return AttributeCollectionResponse
      * @throws ClientExceptionInterface
      */
-    public function fromCollectionResponse(array $collectionData): JsonLDInterface
+    public function fromCollectionResponse(array $collectionResponseData): AttributeCollectionResponse
     {
-        $members = [];
-        foreach ($collectionData['member'] as $attribute) {
-            /** @var AttributeResponse $response */
-            $response = $this->fromResponse($attribute);
-            $members[] = $response;
+        try {
+            return new AttributeCollectionResponse(
+                context: $collectionResponseData['@context'],
+                id: $collectionResponseData['@id'],
+                type: LdType::from($collectionResponseData['@type']),
+                members: array_map(
+                    fn(array $attribute): AttributeResponse => $this->fromResponse($attribute),
+                    $collectionResponseData['member']
+                ),
+                totalItems: $collectionResponseData['totalItems'],
+                view: $collectionResponseData['view'] ?? null,
+                firstPage: $collectionResponseData['firstPage'] ?? null,
+                lastPage: $collectionResponseData['lastPage'] ?? null,
+                nextPage: $collectionResponseData['nextPage'] ?? null,
+                previousPage: $collectionResponseData['previousPage'] ?? null,
+            );
+        } catch (ValueError $exception) {
+            throw new ClientException(
+                message: 'Invalid collection type: ' . $exception->getMessage(),
+                previous: $exception
+            );
         }
-
-        return new AttributeCollectionResponse(
-            context: $collectionData['@context'],
-            id: $collectionData['@id'],
-            type: LdType::from($collectionData['@type']),
-            members: $members,
-            totalItems: $collectionData['totalItems'],
-            view: $collectionData['view'] ?? null,
-            firstPage: $collectionData['firstPage'] ?? null,
-            lastPage: $collectionData['lastPage'] ?? null,
-            nextPage: $collectionData['nextPage'] ?? null,
-            previousPage: $collectionData['previousPage'] ?? null,
-        );
     }
 
     /**

--- a/src/DataMapper/CategoryDataMapper.php
+++ b/src/DataMapper/CategoryDataMapper.php
@@ -15,13 +15,15 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 use Apiera\Sdk\Interface\DTO\ResponseInterface;
 use DateTimeImmutable;
 use Symfony\Component\Uid\Uuid;
+use Throwable;
+use ValueError;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @package Apiera\Sdk\DataMapper
  * @since 0.1.0
  */
-class CategoryDataMapper implements DataMapperInterface
+final class CategoryDataMapper implements DataMapperInterface
 {
     /**
      * @param array<string, mixed> $responseData
@@ -39,41 +41,47 @@ class CategoryDataMapper implements DataMapperInterface
                 updatedAt: new DateTimeImmutable($responseData['updatedAt']),
                 name: $responseData['name'],
                 store: $responseData['store'],
-                description: $responseData['description'],
-                parent: $responseData['parent'],
-                image: $responseData['image'],
+                description: $responseData['description'] ?? null,
+                parent: $responseData['parent'] ?? null,
+                image: $responseData['image'] ?? null,
             );
-        } catch (\DateMalformedStringException $exception) {
-            throw new ClientException($exception->getMessage(), $exception->getCode(), $exception);
+        } catch (Throwable $exception) {
+            throw new ClientException(
+                message: 'Failed to map response data: ' . $exception->getMessage(),
+                previous: $exception
+            );
         }
     }
 
     /**
-     * @param array<string, mixed> $collectionData
+     * @param array<string, mixed> $collectionResponseData
      * @return CategoryCollectionResponse
      * @throws ClientExceptionInterface
      */
-    public function fromCollectionResponse(array $collectionData): CategoryCollectionResponse
+    public function fromCollectionResponse(array $collectionResponseData): CategoryCollectionResponse
     {
-        $members = [];
-        foreach ($collectionData['member'] as $category) {
-            /** @var CategoryResponse $response */
-            $response = $this->fromResponse($category);
-            $members[] = $response;
+        try {
+            return new CategoryCollectionResponse(
+                context: $collectionResponseData['@context'],
+                id: $collectionResponseData['@id'],
+                type: LdType::from($collectionResponseData['@type']),
+                members: array_map(
+                    fn(array $category): CategoryResponse => $this->fromResponse($category),
+                    $collectionResponseData['member']
+                ),
+                totalItems: $collectionResponseData['totalItems'],
+                view: $collectionResponseData['view'] ?? null,
+                firstPage: $collectionResponseData['firstPage'] ?? null,
+                lastPage: $collectionResponseData['lastPage'] ?? null,
+                nextPage: $collectionResponseData['nextPage'] ?? null,
+                previousPage: $collectionResponseData['previousPage'] ?? null,
+            );
+        } catch (ValueError $exception) {
+            throw new ClientException(
+                message: 'Invalid collection type: ' . $exception->getMessage(),
+                previous: $exception
+            );
         }
-
-        return new CategoryCollectionResponse(
-            context: $collectionData['@context'],
-            id: $collectionData['@id'],
-            type: LdType::from($collectionData['@type']),
-            members: $members,
-            totalItems: $collectionData['totalItems'],
-            view: $collectionData['view'] ?? null,
-            firstPage: $collectionData['firstPage'] ?? null,
-            lastPage: $collectionData['lastPage'] ?? null,
-            nextPage: $collectionData['nextPage'] ?? null,
-            previousPage: $collectionData['previousPage'] ?? null,
-        );
     }
 
     /**

--- a/src/Interface/DataMapperInterface.php
+++ b/src/Interface/DataMapperInterface.php
@@ -27,11 +27,11 @@ interface DataMapperInterface
     /**
      * Maps raw API collection response data to an array of strongly-typed DTOs.
      *
-     * @param array<string, mixed> $collectionData
+     * @param array<string, mixed> $collectionResponseData
      * @return JsonLDInterface
      * @throws ClientExceptionInterface
      */
-    public function fromCollectionResponse(array $collectionData): JsonLDInterface;
+    public function fromCollectionResponse(array $collectionResponseData): JsonLDInterface;
 
     /**
      * Maps a request DTO to the format expected by the API.

--- a/tests/Unit/DataMapper/AttributeDataMapperTest.php
+++ b/tests/Unit/DataMapper/AttributeDataMapperTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DataMapper;
+
+use Apiera\Sdk\Interface\ClientExceptionInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Apiera\Sdk\DataMapper\AttributeDataMapper;
+use Apiera\Sdk\DTO\Request\Attribute\AttributeRequest;
+use Apiera\Sdk\DTO\Response\Attribute\AttributeResponse;
+use Apiera\Sdk\DTO\Response\Attribute\AttributeCollectionResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\ClientException;
+use Symfony\Component\Uid\Uuid;
+
+class AttributeDataMapperTest extends TestCase
+{
+    private AttributeDataMapper $mapper;
+    private array $sampleResponseData;
+    private array $sampleCollectionData;
+    private AttributeRequest $sampleRequest;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new AttributeDataMapper();
+
+        $this->sampleResponseData = [
+            '@id' => '/api/attributes/123',
+            '@type' => 'Attribute',
+            'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'createdAt' => '2025-01-01T00:00:00+00:00',
+            'updatedAt' => '2025-01-01T00:00:00+00:00',
+            'name' => 'Test Attribute',
+            'store' => '/api/stores/123'
+        ];
+
+        $this->sampleCollectionData = [
+            '@context' => '/api/contexts/Attribute',
+            '@id' => '/api/attributes',
+            '@type' => 'Collection',
+            'member' => [$this->sampleResponseData],
+            'totalItems' => 1,
+            'view' => '/api/attributes?page=1',
+            'firstPage' => '/api/attributes?page=1',
+            'lastPage' => '/api/attributes?page=1',
+            'nextPage' => null,
+            'previousPage' => null
+        ];
+
+        $this->sampleRequest = new AttributeRequest(
+            name: 'Test Attribute',
+            store: '/api/stores/123'
+        );
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromResponseMapsAllFieldsCorrectly(): void
+    {
+        $result = $this->mapper->fromResponse($this->sampleResponseData);
+
+        $this->assertInstanceOf(AttributeResponse::class, $result);
+        $this->assertEquals('/api/attributes/123', $result->getLdId());
+        $this->assertEquals(LdType::Attribute, $result->getLdType());
+        $this->assertEquals(Uuid::fromString('123e4567-e89b-12d3-a456-426614174000'), $result->getUuid());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getCreatedAt());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getUpdatedAt());
+        $this->assertEquals('Test Attribute', $result->getName());
+        $this->assertEquals('/api/stores/123', $result->getStore());
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromResponseThrowsExceptionForInvalidDate(): void
+    {
+        $data = $this->sampleResponseData;
+        $data['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromResponse($data);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromCollectionResponseThrowsExceptionForInvalidType(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['@type'] = 'InvalidType';
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Invalid collection type');
+        $this->mapper->fromCollectionResponse($data);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromCollectionResponseMapsDataCorrectly(): void
+    {
+        $result = $this->mapper->fromCollectionResponse($this->sampleCollectionData);
+
+        $this->assertInstanceOf(AttributeCollectionResponse::class, $result);
+        $this->assertEquals('/api/contexts/Attribute', $result->getLdContext());
+        $this->assertEquals('/api/attributes', $result->getLdId());
+        $this->assertEquals(LdType::Collection, $result->getLdType());
+        $this->assertEquals(1, $result->getTotalItems());
+        $this->assertCount(1, $result->getMembers());
+        $this->assertInstanceOf(AttributeResponse::class, $result->getMembers()[0]);
+        $this->assertEquals('/api/attributes?page=1', $result->getView());
+        $this->assertEquals('/api/attributes?page=1', $result->getFirstPage());
+        $this->assertEquals('/api/attributes?page=1', $result->getLastPage());
+        $this->assertNull($result->getNextPage());
+        $this->assertNull($result->getPreviousPage());
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromCollectionResponseHandlesEmptyCollection(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'] = [];
+        $data['totalItems'] = 0;
+
+        $result = $this->mapper->fromCollectionResponse($data);
+
+        $this->assertEmpty($result->getMembers());
+        $this->assertEquals(0, $result->getTotalItems());
+    }
+
+    public function testToRequestDataIncludesRequiredFields(): void
+    {
+        $result = $this->mapper->toRequestData($this->sampleRequest);
+
+        $expected = [
+            'name' => 'Test Attribute'
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromCollectionResponseWithInvalidMemberThrowsException(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'][0]['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromCollectionResponse($data);
+    }
+}

--- a/tests/Unit/DataMapper/CategoryDataMapperTest.php
+++ b/tests/Unit/DataMapper/CategoryDataMapperTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DataMapper;
+
+use Apiera\Sdk\Interface\ClientExceptionInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Apiera\Sdk\DataMapper\CategoryDataMapper;
+use Apiera\Sdk\DTO\Request\Category\CategoryRequest;
+use Apiera\Sdk\DTO\Response\Category\CategoryResponse;
+use Apiera\Sdk\DTO\Response\Category\CategoryCollectionResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\ClientException;
+use Symfony\Component\Uid\Uuid;
+
+class CategoryDataMapperTest extends TestCase
+{
+    private CategoryDataMapper $mapper;
+    private array $sampleResponseData;
+    private array $sampleCollectionData;
+    private CategoryRequest $sampleRequest;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new CategoryDataMapper();
+
+        // Sample response data
+        $this->sampleResponseData = [
+            '@id' => '/api/categories/123',
+            '@type' => 'Category',
+            'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'createdAt' => '2025-01-01T00:00:00+00:00',
+            'updatedAt' => '2025-01-01T00:00:00+00:00',
+            'name' => 'Test Category',
+            'store' => '/api/stores/123',
+            'description' => 'Test Description',
+            'parent' => '/api/categories/parent',
+            'image' => '/api/files/123'
+        ];
+
+        // Sample collection data
+        $this->sampleCollectionData = [
+            '@context' => '/api/contexts/Category',
+            '@id' => '/api/categories',
+            '@type' => 'Collection',
+            'member' => [$this->sampleResponseData],
+            'totalItems' => 1,
+            'view' => '/api/categories?page=1',
+            'firstPage' => '/api/categories?page=1',
+            'lastPage' => '/api/categories?page=1',
+            'nextPage' => null,
+            'previousPage' => null
+        ];
+
+        // Sample request
+        $this->sampleRequest = new CategoryRequest(
+            name: 'Test Category',
+            store: '/api/stores/123',
+            description: 'Test Description',
+            parent: '/api/categories/parent',
+            image: '/api/files/123'
+        );
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromResponseMapsAllFieldsCorrectly(): void
+    {
+        $result = $this->mapper->fromResponse($this->sampleResponseData);
+
+        $this->assertInstanceOf(CategoryResponse::class, $result);
+        $this->assertEquals('/api/categories/123', $result->getLdId());
+        $this->assertEquals(LdType::Category, $result->getLdType());
+        $this->assertEquals(Uuid::fromString('123e4567-e89b-12d3-a456-426614174000'), $result->getUuid());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getCreatedAt());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getUpdatedAt());
+        $this->assertEquals('Test Category', $result->getName());
+        $this->assertEquals('/api/stores/123', $result->getStore());
+        $this->assertEquals('Test Description', $result->getDescription());
+        $this->assertEquals('/api/categories/parent', $result->getParent());
+        $this->assertEquals('/api/files/123', $result->getImage());
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromResponseHandlesNullableFieldsCorrectly(): void
+    {
+        $data = $this->sampleResponseData;
+        $data['description'] = null;
+        $data['parent'] = null;
+        $data['image'] = null;
+
+        $result = $this->mapper->fromResponse($data);
+
+        $this->assertNull($result->getDescription());
+        $this->assertNull($result->getParent());
+        $this->assertNull($result->getImage());
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromResponseThrowsExceptionForInvalidDate(): void
+    {
+        $data = $this->sampleResponseData;
+        $data['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromResponse($data);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromCollectionResponseThrowsExceptionForInvalidType(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['@type'] = 'InvalidType';
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Invalid collection type');
+        $this->mapper->fromCollectionResponse($data);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromCollectionResponseMapsDataCorrectly(): void
+    {
+        $result = $this->mapper->fromCollectionResponse($this->sampleCollectionData);
+
+        $this->assertInstanceOf(CategoryCollectionResponse::class, $result);
+        $this->assertEquals('/api/contexts/Category', $result->getLdContext());
+        $this->assertEquals('/api/categories', $result->getLdId());
+        $this->assertEquals(LdType::Collection, $result->getLdType());
+        $this->assertEquals(1, $result->getTotalItems());
+        $this->assertCount(1, $result->getMembers());
+        $this->assertInstanceOf(CategoryResponse::class, $result->getMembers()[0]);
+        $this->assertEquals('/api/categories?page=1', $result->getView());
+        $this->assertEquals('/api/categories?page=1', $result->getFirstPage());
+        $this->assertEquals('/api/categories?page=1', $result->getLastPage());
+        $this->assertNull($result->getNextPage());
+        $this->assertNull($result->getPreviousPage());
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromCollectionResponseHandlesEmptyCollection(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'] = [];
+        $data['totalItems'] = 0;
+
+        $result = $this->mapper->fromCollectionResponse($data);
+
+        $this->assertEmpty($result->getMembers());
+        $this->assertEquals(0, $result->getTotalItems());
+    }
+
+    public function testToRequestDataIncludesRequiredFields(): void
+    {
+        $result = $this->mapper->toRequestData($this->sampleRequest);
+
+        $expected = [
+            'name' => 'Test Category',
+            'description' => 'Test Description',
+            'parent' => '/api/categories/parent',
+            'image' => '/api/files/123'
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testToRequestDataHandlesNullFields(): void
+    {
+        $request = new CategoryRequest(
+            name: 'Test Category'
+        );
+
+        $result = $this->mapper->toRequestData($request);
+
+        $expected = [
+            'name' => 'Test Category',
+            'description' => null,
+            'parent' => null,
+            'image' => null
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     */
+    public function testFromCollectionResponseWithInvalidMemberThrowsException(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'][0]['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromCollectionResponse($data);
+    }
+}


### PR DESCRIPTION
### Description

- Refactored `CategoryDataMapper` and `AttributeDataMapper` for improved readability, immutability, and robust exception handling.  
- Enhanced null field handling to ensure safer data transformations.  
- Added comprehensive unit tests for both mappers, verifying correct response mapping, error scenarios, and collection processing.