### PR TITLE
Update CI/CD workflows for 'release/*' branches

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -5,7 +5,7 @@ on:
     branches: [ '*' ]
   pull_request:
     branches:
-      - 'develop/*'
+      - 'release/*'
       - 'feature/*'
       - 'test/*'
       - 'bug/*'

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -5,7 +5,7 @@ on:
     branches: [ '*' ]
   pull_request:
     branches:
-      - 'develop/*'
+      - 'release/*'
       - 'feature/*'
       - 'test/*'
       - 'bug/*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
     branches: [ '*' ]
   pull_request:
     branches:
-      - 'develop/*'
+      - 'release/*'
       - 'feature/*'
       - 'test/*'
       - 'bug/*'


### PR DESCRIPTION
### Description

This pull request updates GitHub workflows to support `release/*` branches. Changes include replacing `develop/*` with `release/*` in branch filters for static-analysis, code-style, and tests workflows. This ensures workflows align with updated branch naming conventions and operate correctly for release branches.