### PR TITLE
Add File DTOs, mappers, responses, and tests

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,7 +7,7 @@
     - [Attributes](#attributes)
     - [Categories](#categories)
     - [Distributors](#distributors)
-    - [Files](#file)
+    - [Files](#files)
 
 ---
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -7,6 +7,7 @@
     - [Attributes](#attributes)
     - [Categories](#categories)
     - [Distributors](#distributors)
+    - [Files](#file)
 
 ---
 
@@ -302,4 +303,91 @@ $requestObject = new \Apiera\Sdk\DTO\Request\Distributor\DistributorRequest(
 );
 
 $responseObject = $sdk->distributor()->update($requestObject);
+```
+
+## Files
+
+### Find Files
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\File\FileRequest(
+    url: 'https://example.com/images/product.jpg'
+);
+
+$responseObject = $sdk->file()->find($requestObject);
+```
+
+---
+
+### Find Files with Filter and Pagination
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\File\FileRequest(
+    url: 'https://example.com/images/product.jpg'
+);
+
+$queryParamObject = new \Apiera\Sdk\DTO\QueryParameters(
+    filters: ['name' => 'product.jpg'] // Add filters as needed
+);
+
+$responseObject = $sdk->file()->find($requestObject, $queryParamObject);
+```
+
+---
+
+### Search a Single File
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\File\FileRequest(
+    url: 'https://example.com/images/product.jpg'
+);
+
+$queryParamObject = new \Apiera\Sdk\DTO\QueryParameters(
+    filters: ['name' => 'product.jpg'] // Define search criteria
+);
+
+try {
+    $responseObject = $sdk->file()->findOneBy($requestObject, $queryParamObject);
+} catch (\Apiera\Sdk\Exception\InvalidRequestException) {
+    // Handle the case when the file is not found
+}
+```
+
+---
+
+### Find a File
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\File\FileRequest(
+    url: 'https://example.com/images/product.jpg',
+    iri: '/api/v1/files/520413a8-509a-4048-96e6-81751e315c5d' // Use the file IRI
+);
+
+$responseObject = $sdk->file()->get($requestObject);
+```
+
+---
+
+### Create a File
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\File\FileRequest(
+    url: 'https://example.com/images/product.jpg',
+    name: 'product.jpg'
+);
+
+$responseObject = $sdk->file()->create($requestObject);
+```
+
+---
+
+### Delete a File
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\File\FileRequest(
+    url: 'https://example.com/images/product.jpg',
+    iri: '/api/v1/files/520413a8-509a-4048-96e6-81751e315c5d' // Use the file IRI
+);
+
+$sdk->file()->delete($requestObject);
 ```

--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -8,10 +8,12 @@ use Apiera\Sdk\DataMapper\AlternateIdentifierDataMapper;
 use Apiera\Sdk\DataMapper\AttributeDataMapper;
 use Apiera\Sdk\DataMapper\CategoryDataMapper;
 use Apiera\Sdk\DataMapper\DistributorDataMapper;
+use Apiera\Sdk\DataMapper\FileDataMapper;
 use Apiera\Sdk\Resource\AlternateIdentifierResource;
 use Apiera\Sdk\Resource\AttributeResource;
 use Apiera\Sdk\Resource\CategoryResource;
 use Apiera\Sdk\Resource\DistributorResource;
+use Apiera\Sdk\Resource\FileResource;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
@@ -56,5 +58,12 @@ final readonly class ApieraSdk
         $dataMapper = new DistributorDataMapper();
 
         return new DistributorResource($this->client, $dataMapper);
+    }
+
+    public function file(): FileResource
+    {
+        $dataMapper = new FileDataMapper();
+
+        return new FileResource($this->client, $dataMapper);
     }
 }

--- a/src/DTO/Request/File/FileRequest.php
+++ b/src/DTO/Request/File/FileRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\File;
+
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class FileRequest implements RequestInterface
+{
+    /**
+     * @param string $url The file url
+     * @param string|null $name The file name
+     * @param string|null $iri The file iri
+     */
+    public function __construct(
+        private string $url,
+        private ?string $name = null,
+        private ?string $iri = null
+    ) {
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'url' => $this->url,
+            'name' => $this->name,
+        ];
+    }
+}

--- a/src/DTO/Response/File/FileCollectionResponse.php
+++ b/src/DTO/Response/File/FileCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\File;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class FileCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<FileResponse>
+     */
+    public function getMembers(): array
+    {
+        /** @var array<FileResponse> $members */
+        $members = parent::getMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/File/FileResponse.php
+++ b/src/DTO/Response/File/FileResponse.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\File;
+
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class FileResponse extends AbstractResponse
+{
+    public function __construct(
+        string $id,
+        LdType $type,
+        Uuid $uuid,
+        DateTimeInterface $createdAt,
+        DateTimeInterface $updatedAt,
+        private string $url,
+        private ?string $name = null,
+    ) {
+        parent::__construct(
+            $id,
+            $type,
+            $uuid,
+            $createdAt,
+            $updatedAt
+        );
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/src/DataMapper/FileDataMapper.php
+++ b/src/DataMapper/FileDataMapper.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DataMapper;
+
+use Apiera\Sdk\DTO\Response\File\FileCollectionResponse;
+use Apiera\Sdk\DTO\Response\File\FileResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\ClientException;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+use ValueError;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final class FileDataMapper implements DataMapperInterface
+{
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     *
+     * @param array<string, mixed> $responseData
+     */
+    public function fromResponse(array $responseData): FileResponse
+    {
+        try {
+            return new FileResponse(
+                id: $responseData['@id'],
+                type: LdType::from($responseData['@type']),
+                uuid: Uuid::fromString($responseData['uuid']),
+                createdAt: new DateTimeImmutable($responseData['createdAt']),
+                updatedAt: new DateTimeImmutable($responseData['updatedAt']),
+                url: $responseData['url'],
+                name: $responseData['name']
+            );
+        } catch (Throwable $exception) {
+            throw new ClientException(
+                message: 'Failed to map response data: ' . $exception->getMessage(),
+                previous: $exception
+            );
+        }
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     *
+     * @param array<string, mixed> $collectionResponseData
+     */
+    public function fromCollectionResponse(array $collectionResponseData): FileCollectionResponse
+    {
+        try {
+            return new FileCollectionResponse(
+                context: $collectionResponseData['@context'],
+                id: $collectionResponseData['@id'],
+                type: LdType::from($collectionResponseData['@type']),
+                members: array_map(
+                    fn(array $file): FileResponse => $this->fromResponse($file),
+                    $collectionResponseData['member']
+                ),
+                totalItems: $collectionResponseData['totalItems'],
+                view: $collectionResponseData['view'] ?? null,
+                firstPage: $collectionResponseData['firstPage'] ?? null,
+                lastPage: $collectionResponseData['lastPage'] ?? null,
+                nextPage: $collectionResponseData['nextPage'] ?? null,
+                previousPage: $collectionResponseData['previousPage'] ?? null,
+            );
+        } catch (ValueError $exception) {
+            throw new ClientException(
+                message: 'Invalid collection type: ' . $exception->getMessage(),
+                previous: $exception
+            );
+        }
+    }
+
+    /**
+     * @param \Apiera\Sdk\DTO\Request\Attribute\AttributeRequest $requestDto
+     *
+     * @return array<string, mixed>
+     */
+    public function toRequestData(RequestInterface $requestDto): array
+    {
+        return $requestDto->toArray();
+    }
+}

--- a/src/DataMapper/FileDataMapper.php
+++ b/src/DataMapper/FileDataMapper.php
@@ -78,7 +78,7 @@ final class FileDataMapper implements DataMapperInterface
     }
 
     /**
-     * @param \Apiera\Sdk\DTO\Request\Attribute\AttributeRequest $requestDto
+     * @param \Apiera\Sdk\DTO\Request\File\FileRequest $requestDto
      *
      * @return array<string, mixed>
      */

--- a/src/Exception/NotSupportedOperationException.php
+++ b/src/Exception/NotSupportedOperationException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Exception;
+
+use Exception;
+
+/**
+ * Exception thrown when attempting to use an unsupported operation.
+ *
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final class NotSupportedOperationException extends Exception
+{
+}

--- a/src/Resource/FileResource.php
+++ b/src/Resource/FileResource.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\File\FileRequest;
+use Apiera\Sdk\DTO\Response\File\FileCollectionResponse;
+use Apiera\Sdk\DTO\Response\File\FileResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\NotSupportedOperationException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class FileResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/api/v1/files';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function find(RequestInterface $request, ?QueryParameters $params = null): FileCollectionResponse
+    {
+        if (!$request instanceof FileRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', FileRequest::class)
+            );
+        }
+
+        /** @var FileCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get(self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): FileResponse
+    {
+        if (!$request instanceof FileRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', FileRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getTotalItems() < 1) {
+            throw new InvalidRequestException('No file found matching the given criteria');
+        }
+
+        return $collection->getMembers()[0];
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function get(RequestInterface $request): FileResponse
+    {
+        if (!$request instanceof FileRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', FileRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('File IRI is required for this operation');
+        }
+
+        /** @var FileResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function create(RequestInterface $request): FileResponse
+    {
+        if (!$request instanceof FileRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', FileRequest::class)
+            );
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var FileResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post(self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws NotSupportedOperationException
+     */
+    public function update(RequestInterface $request): FileResponse
+    {
+        throw new NotSupportedOperationException('The file resource does not support update operations');
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof FileRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', FileRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('File IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/tests/Integration/Resource/FileResourceTest.php
+++ b/tests/Integration/Resource/FileResourceTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource;
+
+use Apiera\Sdk\ApieraSdk;
+use Apiera\Sdk\Configuration;
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\File\FileRequest;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class FileResourceTest extends TestCase
+{
+    private MockHandler $mockHandler;
+
+    /** @var array<int, array<string, mixed>>|\ArrayAccess<int, array<string, mixed>> */
+    private array|\ArrayAccess $requestHistory = [];
+    private ApieraSdk $sdk;
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testFindFilesFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $fileId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $fileData = [
+            '@context' => '/api/v1/contexts/File',
+            '@id' => '/api/v1/files',
+            '@type' => 'Collection',
+            'member' => [[
+                '@id' => sprintf('%s/files/%s', $baseUrl, $fileId),
+                '@type' => 'File',
+                'uuid' => $fileId,
+                'createdAt' => '2024-12-17T09:18:32+00:00',
+                'updatedAt' => '2024-12-17T09:18:32+00:00',
+                'url' => 'https://example.com/test.jpg',
+                'name' => 'test.jpg',
+            ]],
+            'totalItems' => 1,
+        ];
+        $this->mockHandler->append(new Response(200, [], json_encode($fileData)));
+
+        $request = new FileRequest(
+            url: 'https://example.com/test.jpg',
+            name: 'test.jpg'
+        );
+
+        $response = $this->sdk->file()->find($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $fileRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('GET', $fileRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $fileRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/ld+json', $fileRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf('%s/files', $baseUrl),
+            (string)$fileRequest->getUri()
+        );
+
+        $this->assertEquals(1, $response->getTotalItems());
+        $this->assertCount(1, $response->getMembers());
+        $this->assertEquals('test.jpg', $response->getMembers()[0]->getName());
+        $this->assertEquals('https://example.com/test.jpg', $response->getMembers()[0]->getUrl());
+        $this->assertEquals($fileId, $response->getMembers()[0]->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testFindOneByFileFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $fileId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $fileData = [
+            '@context' => '/api/v1/contexts/File',
+            '@id' => '/api/v1/files',
+            '@type' => 'Collection',
+            'member' => [[
+                '@id' => sprintf('%s/files/%s', $baseUrl, $fileId),
+                '@type' => 'File',
+                'uuid' => $fileId,
+                'createdAt' => '2024-12-17T09:18:32+00:00',
+                'updatedAt' => '2024-12-17T09:18:32+00:00',
+                'url' => 'https://example.com/test.jpg',
+                'name' => 'test.jpg',
+            ]],
+            'totalItems' => 1,
+        ];
+        $this->mockHandler->append(new Response(200, [], json_encode($fileData)));
+
+        $request = new FileRequest(
+            url: 'https://example.com/test.jpg',
+            name: 'test.jpg'
+        );
+
+        $params = new QueryParameters(filters: ['name' => 'test.jpg']);
+        $response = $this->sdk->file()->findOneBy($request, $params);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $fileRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('GET', $fileRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $fileRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/ld+json', $fileRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf(
+                '%s/files?filters%%5Bname%%5D=%s',
+                $baseUrl,
+                rawurlencode('test.jpg')
+            ),
+            (string)$fileRequest->getUri()
+        );
+
+        $this->assertEquals('test.jpg', $response->getName());
+        $this->assertEquals('https://example.com/test.jpg', $response->getUrl());
+        $this->assertEquals($fileId, $response->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testCreateFileFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $fileId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $fileData = [
+            '@id' => sprintf('%s/files/%s', $baseUrl, $fileId),
+            '@type' => 'File',
+            'uuid' => $fileId,
+            'createdAt' => '2024-12-17T09:18:32+00:00',
+            'updatedAt' => '2024-12-17T09:18:32+00:00',
+            'url' => 'https://example.com/test.jpg',
+            'name' => 'test.jpg',
+        ];
+        $this->mockHandler->append(new Response(201, [], json_encode($fileData)));
+
+        $request = new FileRequest(
+            url: 'https://example.com/test.jpg',
+            name: 'test.jpg'
+        );
+
+        $response = $this->sdk->file()->create($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $fileRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('POST', $fileRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $fileRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/ld+json', $fileRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf('%s/files', $baseUrl),
+            (string)$fileRequest->getUri()
+        );
+
+        $this->assertEquals('test.jpg', $response->getName());
+        $this->assertEquals('https://example.com/test.jpg', $response->getUrl());
+        $this->assertEquals($fileId, $response->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testDeleteFileFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $this->mockHandler->append(new Response(204));
+
+        $fileId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $request = new FileRequest(
+            url: 'https://example.com/test.jpg',
+            name: 'test.jpg',
+            iri: sprintf('%s/files/%s', $baseUrl, $fileId)
+        );
+
+        $this->sdk->file()->delete($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $fileRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('DELETE', $fileRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $fileRequest->getHeader('Authorization')[0]);
+        $this->assertEquals(
+            sprintf('%s/files/%s', $baseUrl, $fileId),
+            (string)$fileRequest->getUri()
+        );
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     * @throws \Apiera\Sdk\Exception\ClientException
+     */
+    protected function setUp(): void
+    {
+        $this->mockHandler = new MockHandler();
+        $handlerStack = HandlerStack::create($this->mockHandler);
+
+        $history = Middleware::history($this->requestHistory);
+        $handlerStack->push($history);
+
+        $cacheItemMock = $this->createMock(CacheItemInterface::class);
+        $cacheItemMock->method('isHit')->willReturn(false);
+        $cacheItemMock->method('get')->willReturn(null);
+        $cacheItemMock->method('set')->willReturnSelf();
+        $cacheItemMock->method('expiresAfter')->willReturnSelf();
+
+        $cacheMock = $this->createMock(CacheItemPoolInterface::class);
+        $cacheMock->method('getItem')->willReturn($cacheItemMock);
+        $cacheMock->method('save')->willReturn(true);
+
+        $config = new Configuration(
+            baseUrl: 'https://api.test',
+            userAgent: 'Test/1.0',
+            oauthDomain: 'auth.test',
+            oauthClientId: 'test_client',
+            oauthClientSecret: 'test_secret',
+            oauthCookieSecret: 'test_cookie',
+            oauthAudience: 'test_audience',
+            oauthOrganizationId: 'test_org',
+            cache: $cacheMock,
+            timeout: 10,
+            debugMode: false,
+            options: [
+                'handler' => $handlerStack,
+            ]
+        );
+
+        $this->sdk = new ApieraSdk($config);
+    }
+}

--- a/tests/Unit/DTO/Request/File/FileRequestTest.php
+++ b/tests/Unit/DTO/Request/File/FileRequestTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\File;
+
+use Apiera\Sdk\DTO\Request\File\FileRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use PHPUnit\Framework\TestCase;
+
+final class FileRequestTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $request = new FileRequest('', '');
+
+        $this->assertInstanceOf(FileRequest::class, $request);
+        $this->assertInstanceOf(RequestInterface::class, $request);
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $request = new FileRequest(
+            url: 'https://example.com/file.pdf',
+            name: 'Example File',
+            iri: '/api/v1/files/123'
+        );
+
+        $this->assertEquals('Example File', $request->getName());
+        $this->assertEquals('https://example.com/file.pdf', $request->getUrl());
+        $this->assertEquals('/api/v1/files/123', $request->getIri());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $request = new FileRequest(url: 'https://example.com/file.pdf');
+
+        $this->assertEquals('https://example.com/file.pdf', $request->getUrl());
+        $this->assertNull($request->getName());
+        $this->assertNull($request->getIri());
+    }
+
+    public function testToArray(): void
+    {
+        $request = new FileRequest(
+            url: 'https://example.com/file.pdf',
+            name: 'Example File',
+            iri: '/api/v1/files/123'
+        );
+
+        $array = $request->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('url', $array);
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayNotHasKey('iri', $array);
+
+        $this->assertEquals('https://example.com/file.pdf', $array['url']);
+        $this->assertEquals('Example File', $array['name']);
+        $this->assertEquals(
+            ['url' => 'https://example.com/file.pdf', 'name' => 'Example File'],
+            $array
+        );
+    }
+}

--- a/tests/Unit/DTO/Response/File/FileCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/File/FileCollectionResponseTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\File;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+use Apiera\Sdk\DTO\Response\File\FileCollectionResponse;
+use Apiera\Sdk\DTO\Response\File\FileResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDCollectionInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+final class FileCollectionResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new FileCollectionResponse(
+            context: '',
+            id: '',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertInstanceOf(FileCollectionResponse::class, $response);
+        $this->assertInstanceOf(AbstractCollectionResponse::class, $response);
+        $this->assertInstanceOf(JsonLDCollectionInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(FileCollectionResponse::class);
+
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $fileResponse = new FileResponse(
+            id: '/api/v1/files/123',
+            type: LdType::File,
+            uuid: Uuid::v4(),
+            createdAt: new DateTimeImmutable(),
+            updatedAt: new DateTimeImmutable(),
+            url: 'https://example.com/file.pdf',
+            name: 'test-file.pdf'
+        );
+
+        $response = new FileCollectionResponse(
+            context: '/api/v1/contexts/File',
+            id: '/api/v1/files',
+            type: LdType::Collection,
+            members: [$fileResponse],
+            totalItems: 1,
+            view: '/api/v1/files?page=1',
+            firstPage: '/api/v1/files?page=1',
+            lastPage: '/api/v1/files?page=1',
+            nextPage: null,
+            previousPage: null
+        );
+
+        $this->assertEquals('/api/v1/contexts/File', $response->getLdContext());
+        $this->assertEquals('/api/v1/files', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertCount(1, $response->getMembers());
+        $this->assertInstanceOf(FileResponse::class, $response->getMembers()[0]);
+        $this->assertEquals(1, $response->getTotalItems());
+        $this->assertEquals('/api/v1/files?page=1', $response->getView());
+        $this->assertEquals('/api/v1/files?page=1', $response->getFirstPage());
+        $this->assertEquals('/api/v1/files?page=1', $response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $response = new FileCollectionResponse(
+            context: '/api/v1/contexts/File',
+            id: '/api/v1/files',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertEquals('/api/v1/contexts/File', $response->getLdContext());
+        $this->assertEquals('/api/v1/files', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertEmpty($response->getMembers());
+        $this->assertEquals(0, $response->getTotalItems());
+        $this->assertNull($response->getView());
+        $this->assertNull($response->getFirstPage());
+        $this->assertNull($response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+}

--- a/tests/Unit/DTO/Response/File/FileResponseTest.php
+++ b/tests/Unit/DTO/Response/File/FileResponseTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\File;
+
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\DTO\Response\File\FileResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDInterface;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+final class FileResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new FileResponse(
+            id: '',
+            type: LdType::File,
+            uuid: Uuid::v4(),
+            createdAt: new DateTimeImmutable(),
+            updatedAt: new DateTimeImmutable(),
+            url: '',
+            name: null
+        );
+
+        $this->assertInstanceOf(FileResponse::class, $response);
+        $this->assertInstanceOf(AbstractResponse::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(JsonLDInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(FileResponse::class);
+
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testPropertiesAreReadonly(): void
+    {
+        $reflection = new ReflectionClass(FileResponse::class);
+        $properties = $reflection->getProperties();
+
+        foreach ($properties as $property) {
+            $this->assertTrue($property->isReadonly(), sprintf('Property %s should be readonly', $property->getName()));
+        }
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $response = new FileResponse(
+            id: '/api/v1/files/123',
+            type: LdType::File,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            url: 'https://example.com/file.pdf',
+            name: 'test-file.pdf'
+        );
+
+        $this->assertEquals('/api/v1/files/123', $response->getLdId());
+        $this->assertEquals(LdType::File, $response->getLdType());
+        $this->assertTrue(Uuid::isValid($response->getUuid()->toRfc4122()));
+        $this->assertEquals('bfd2639c-7793-426a-a413-ea262e582208', $response->getUuid()->toRfc4122());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getCreatedAt());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getUpdatedAt());
+        $this->assertEquals('https://example.com/file.pdf', $response->getUrl());
+        $this->assertEquals('test-file.pdf', $response->getName());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $response = new FileResponse(
+            id: '/api/v1/files/123',
+            type: LdType::File,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            url: 'https://example.com/file.pdf',
+            name: null
+        );
+
+        $this->assertEquals('/api/v1/files/123', $response->getLdId());
+        $this->assertEquals(LdType::File, $response->getLdType());
+        $this->assertTrue(Uuid::isValid($response->getUuid()->toRfc4122()));
+        $this->assertEquals('bfd2639c-7793-426a-a413-ea262e582208', $response->getUuid()->toRfc4122());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getCreatedAt());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getUpdatedAt());
+        $this->assertEquals('https://example.com/file.pdf', $response->getUrl());
+        $this->assertNull($response->getName());
+    }
+}

--- a/tests/Unit/DataMapper/FileDataMapperTest.php
+++ b/tests/Unit/DataMapper/FileDataMapperTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DataMapper;
+
+use Apiera\Sdk\DataMapper\FileDataMapper;
+use Apiera\Sdk\DTO\Request\File\FileRequest;
+use Apiera\Sdk\DTO\Response\File\FileCollectionResponse;
+use Apiera\Sdk\DTO\Response\File\FileResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\ClientException;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class FileDataMapperTest extends TestCase
+{
+    private FileDataMapper $mapper;
+
+    /** @var array<string, mixed> */
+    private array $sampleResponseData;
+
+    /** @var array<string, mixed> */
+    private array $sampleCollectionData;
+    private FileRequest $sampleRequest;
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromResponseMapsAllFieldsCorrectly(): void
+    {
+        $result = $this->mapper->fromResponse($this->sampleResponseData);
+
+        $this->assertInstanceOf(FileResponse::class, $result);
+        $this->assertEquals('/api/v1/files/123', $result->getLdId());
+        $this->assertEquals(LdType::File, $result->getLdType());
+        $this->assertEquals(Uuid::fromString('123e4567-e89b-12d3-a456-426614174000'), $result->getUuid());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getCreatedAt());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getUpdatedAt());
+        $this->assertEquals('https://example.com/test-file.jpg', $result->getUrl());
+        $this->assertEquals('test-file.jpg', $result->getName());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromResponseThrowsExceptionForInvalidDate(): void
+    {
+        $data = $this->sampleResponseData;
+        $data['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromResponse($data);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseThrowsExceptionForInvalidType(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['@type'] = 'InvalidType';
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Invalid collection type');
+        $this->mapper->fromCollectionResponse($data);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseMapsDataCorrectly(): void
+    {
+        $result = $this->mapper->fromCollectionResponse($this->sampleCollectionData);
+
+        $this->assertInstanceOf(FileCollectionResponse::class, $result);
+        $this->assertEquals('/api/v1/contexts/File', $result->getLdContext());
+        $this->assertEquals('/api/v1/files', $result->getLdId());
+        $this->assertEquals(LdType::Collection, $result->getLdType());
+        $this->assertEquals(1, $result->getTotalItems());
+        $this->assertCount(1, $result->getMembers());
+        $this->assertInstanceOf(FileResponse::class, $result->getMembers()[0]);
+        $this->assertEquals('/api/v1/files?page=1', $result->getView());
+        $this->assertEquals('/api/v1/files?page=1', $result->getFirstPage());
+        $this->assertEquals('/api/v1/files?page=1', $result->getLastPage());
+        $this->assertNull($result->getNextPage());
+        $this->assertNull($result->getPreviousPage());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseHandlesEmptyCollection(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'] = [];
+        $data['totalItems'] = 0;
+
+        $result = $this->mapper->fromCollectionResponse($data);
+
+        $this->assertEmpty($result->getMembers());
+        $this->assertEquals(0, $result->getTotalItems());
+    }
+
+    public function testToRequestDataIncludesRequiredFields(): void
+    {
+        $result = $this->mapper->toRequestData($this->sampleRequest);
+
+        $expected = [
+            'url' => 'https://example.com/test-file.jpg',
+            'name' => 'test-file.jpg',
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseWithInvalidMemberThrowsException(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'][0]['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromCollectionResponse($data);
+    }
+
+    protected function setUp(): void
+    {
+        $this->mapper = new FileDataMapper();
+
+        $this->sampleResponseData = [
+            '@id' => '/api/v1/files/123',
+            '@type' => 'File',
+            'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'createdAt' => '2025-01-01T00:00:00+00:00',
+            'updatedAt' => '2025-01-01T00:00:00+00:00',
+            'url' => 'https://example.com/test-file.jpg',
+            'name' => 'test-file.jpg',
+        ];
+
+        $this->sampleCollectionData = [
+            '@context' => '/api/v1/contexts/File',
+            '@id' => '/api/v1/files',
+            '@type' => 'Collection',
+            'member' => [$this->sampleResponseData],
+            'totalItems' => 1,
+            'view' => '/api/v1/files?page=1',
+            'firstPage' => '/api/v1/files?page=1',
+            'lastPage' => '/api/v1/files?page=1',
+            'nextPage' => null,
+            'previousPage' => null,
+        ];
+
+        $this->sampleRequest = new FileRequest(
+            url: 'https://example.com/test-file.jpg',
+            name: 'test-file.jpg'
+        );
+    }
+}

--- a/tests/Unit/Resource/FileResourceTest.php
+++ b/tests/Unit/Resource/FileResourceTest.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Resource;
+
+use Apiera\Sdk\Client;
+use Apiera\Sdk\DataMapper\FileDataMapper;
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\File\FileRequest;
+use Apiera\Sdk\DTO\Response\File\FileCollectionResponse;
+use Apiera\Sdk\DTO\Response\File\FileResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\NotSupportedOperationException;
+use Apiera\Sdk\Resource\FileResource;
+use DateTimeImmutable;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class FileResourceTest extends TestCase
+{
+    private Client|MockObject $clientMock;
+    private FileDataMapper|MockObject $mapperMock;
+    private FileResource $resource;
+    private FileRequest $request;
+    private FileResponse $response;
+    private FileCollectionResponse $collectionResponse;
+
+    /** @var array<string, mixed> */
+    private array $mockResponseData;
+
+    /** @var array<string, mixed> */
+    private array $mockCollectionData;
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testFindReturnsCollection(): void
+    {
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->clientMock->expects($this->once())
+            ->method('get')
+            ->with('/api/v1/files')
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($this->mockCollectionData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromCollectionResponse')
+            ->with($this->mockCollectionData)
+            ->willReturn($this->collectionResponse);
+
+        $result = $this->resource->find($this->request);
+        $this->assertSame($this->collectionResponse, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testFindOneByReturnsFirstResult(): void
+    {
+        $params = new QueryParameters(filters: ['name' => 'test.jpg']);
+
+        $this->clientMock->expects($this->once())
+            ->method('get')
+            ->with('/api/v1/files')
+            ->willReturn($this->createMock(ResponseInterface::class));
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->willReturn($this->mockCollectionData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromCollectionResponse')
+            ->willReturn($this->collectionResponse);
+
+        $result = $this->resource->findOneBy($this->request, $params);
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testFindOneByThrowsExceptionWhenEmpty(): void
+    {
+        $emptyCollectionData = [
+            '@context' => '/api/contexts/File',
+            '@id' => '/api/v1/files',
+            '@type' => 'Collection',
+            'member' => [],
+            'totalItems' => 0,
+        ];
+
+        $emptyCollection = new FileCollectionResponse(
+            context: '/api/v1/contexts/File',
+            id: '/api/v1/files',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->clientMock->method('get')
+            ->willReturn($this->createMock(ResponseInterface::class));
+
+        $this->clientMock->method('decodeResponse')
+            ->willReturn($emptyCollectionData);
+
+        $this->mapperMock->method('fromCollectionResponse')
+            ->willReturn($emptyCollection);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->findOneBy($this->request, new QueryParameters());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testGetRequiresIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->get(new FileRequest(url: 'https://example.com/test.jpg'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testGetReturnsFile(): void
+    {
+        $request = new FileRequest(
+            url: 'https://example.com/test.jpg',
+            name: 'test.jpg',
+            iri: '/api/v1/files/456'
+        );
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->clientMock->expects($this->once())
+            ->method('get')
+            ->with('/api/v1/files/456')
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($this->mockResponseData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromResponse')
+            ->with($this->mockResponseData)
+            ->willReturn($this->response);
+
+        $result = $this->resource->get($request);
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testCreateFile(): void
+    {
+        $requestData = [
+            'url' => 'https://example.com/test.jpg',
+            'name' => 'test.jpg',
+        ];
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->mapperMock->expects($this->once())
+            ->method('toRequestData')
+            ->with($this->request)
+            ->willReturn($requestData);
+
+        $this->clientMock->expects($this->once())
+            ->method('post')
+            ->with('/api/v1/files', $requestData)
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($this->mockResponseData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromResponse')
+            ->with($this->mockResponseData)
+            ->willReturn($this->response);
+
+        $result = $this->resource->create($this->request);
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testUpdateThrowsNotSupportedException(): void
+    {
+        $this->expectException(NotSupportedOperationException::class);
+        $this->resource->update($this->request);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testDeleteRequiresIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->delete(new FileRequest(url: 'https://example.com/test.jpg'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testDeleteFile(): void
+    {
+        $request = new FileRequest(
+            url: 'https://example.com/test.jpg',
+            name: 'test.jpg',
+            iri: '/api/v1/files/456'
+        );
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->clientMock->expects($this->once())
+            ->method('delete')
+            ->with('/api/v1/files/456')
+            ->willReturn($responseMock);
+
+        $this->resource->delete($request);
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    protected function setUp(): void
+    {
+        $this->clientMock = $this->createMock(Client::class);
+        $this->mapperMock = $this->createMock(FileDataMapper::class);
+        $this->resource = new FileResource($this->clientMock, $this->mapperMock);
+
+        // Setup realistic test data
+        $this->request = new FileRequest(
+            url: 'https://example.com/test.jpg',
+            name: 'test.jpg'
+        );
+
+        $uuid = Uuid::fromString('f47ac10b-58cc-4372-a567-0e02b2c3d479');
+        $createdAt = new DateTimeImmutable('2024-01-25T12:00:00+00:00');
+        $updatedAt = new DateTimeImmutable('2024-01-25T12:00:00+00:00');
+
+        $this->response = new FileResponse(
+            id: '/api/v1/files/456',
+            type: LdType::File,
+            uuid: $uuid,
+            createdAt: $createdAt,
+            updatedAt: $updatedAt,
+            url: 'https://example.com/test.jpg',
+            name: 'test.jpg'
+        );
+
+        $this->mockResponseData = [
+            '@id' => '/api/v1/files/456',
+            '@type' => 'File',
+            'uuid' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            'url' => 'https://example.com/test.jpg',
+            'name' => 'test.jpg',
+            'createdAt' => '2024-01-25T12:00:00+00:00',
+            'updatedAt' => '2024-01-25T12:00:00+00:00',
+        ];
+
+        $this->mockCollectionData = [
+            '@context' => '/api/v1/contexts/File',
+            '@id' => '/api/v1/files',
+            '@type' => 'Collection',
+            'member' => [$this->mockResponseData],
+            'totalItems' => 1,
+            'view' => '/api/v1/files?page=1',
+            'firstPage' => '/api/v1/files?page=1',
+            'lastPage' => '/api/v1/files?page=1',
+        ];
+
+        $this->collectionResponse = new FileCollectionResponse(
+            context: '/api/v1/contexts/File',
+            id: '/api/files',
+            type: LdType::Collection,
+            members: [$this->response],
+            totalItems: 1,
+            view: '/api/v1/files?page=1',
+            firstPage: '/api/v1/files?page=1',
+            lastPage: '/api/v1/files?page=1'
+        );
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces the following additions to the project:

- **`FileRequest` DTO**: Implements the `RequestInterface` for managing file-related requests. Includes structure, constructor, getters, and a `toArray` method with accompanying tests.
- **`FileResponse` DTO**: Represents file-related responses with readonly properties for URL and an optional name attribute. Includes tests to validate behavior and inheritance.
- **`FileCollectionResponse`**: Extends `AbstractCollectionResponse` with type-hinting for `FileResponse` members, ensuring proper structure and behavior through comprehensive tests.
- **`FileDataMapper`**: Maps file response data to DTOs and handles collections with robust exception handling. Includes tests verifying field mapping, invalid data handling, and request transformation.
- **`FileResource`**: Implements `RequestResourceInterface` for file-related operations, providing CRUD functionality through the `/api/v1/files` endpoint (excluding update operations) with comprehensive test coverage.
- **`NotSupportedOperationException`**: New exception class for handling unsupported operations in resources.