### PR TITLE
Refactor and introduce support for attribute term data handling

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,6 +10,7 @@
     - [Files](#files)
     - [Brands](#brands)
     - [Properties](#properties)
+    - [Attribute Terms](#attribute-terms)
 
 ---
 
@@ -580,4 +581,95 @@ $requestObject = new \Apiera\Sdk\DTO\Request\Property\PropertyRequest(
 );
 
 $sdk->property()->delete($requestObject);
+```
+
+## Attribute Terms
+
+### Find Attribute Terms
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest(
+    name: '32GB',
+    attribute: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/attributes/520413a8-509a-4048-96e6-81751e315c5d2'
+);
+
+$responseObject = $sdk->attributeTerm()->find($requestObject);
+```
+
+### Find Attribute Terms with Filter and Pagination
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest(
+    name: '32GB',
+    attribute: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/attributes/520413a8-509a-4048-96e6-81751e315c5d2'
+);
+
+$queryParamObject = new \Apiera\Sdk\DTO\QueryParameters(
+    filters: ['name' => '32GB'] // Add filters as needed
+);
+
+$responseObject = $sdk->attributeTerm()->find($requestObject, $queryParamObject);
+```
+
+### Search a Single Attribute Term
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest(
+    name: '32GB',
+    attribute: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/attributes/520413a8-509a-4048-96e6-81751e315c5d2'
+);
+
+$queryParamObject = new \Apiera\Sdk\DTO\QueryParameters(
+    filters: ['name' => '32GB'] // Define search criteria
+);
+
+try {
+    $responseObject = $sdk->attributeTerm()->findOneBy($requestObject, $queryParamObject);
+} catch (\Apiera\Sdk\Exception\InvalidRequestException) {
+    // Handle the case when the attribute term is not found
+}
+```
+
+### Find an Attribute Term
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest(
+    name: '32GB',
+    iri: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/attributes/520413a8-509a-4048-96e6-81751e315c5d2/terms/520413a8-509a-4048-96e6-81751e315c5d3'
+);
+
+$responseObject = $sdk->attributeTerm()->get($requestObject);
+```
+
+### Create an Attribute Term
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest(
+    name: '32GB',
+    attribute: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/attributes/520413a8-509a-4048-96e6-81751e315c5d2'
+);
+
+$responseObject = $sdk->attributeTerm()->create($requestObject);
+```
+
+### Update an Attribute Term
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest(
+    name: '64GB',
+    iri: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/attributes/520413a8-509a-4048-96e6-81751e315c5d2/terms/520413a8-509a-4048-96e6-81751e315c5d3'
+);
+
+$responseObject = $sdk->attributeTerm()->update($requestObject);
+```
+
+### Delete an Attribute Term
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest(
+    name: '32GB',
+    iri: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/attributes/520413a8-509a-4048-96e6-81751e315c5d2/terms/520413a8-509a-4048-96e6-81751e315c5d3'
+);
+
+$sdk->attributeTerm()->delete($requestObject);
 ```

--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -6,11 +6,13 @@ namespace Apiera\Sdk;
 
 use Apiera\Sdk\DataMapper\AlternateIdentifierDataMapper;
 use Apiera\Sdk\DataMapper\AttributeDataMapper;
+use Apiera\Sdk\DataMapper\AttributeTermDataMapper;
 use Apiera\Sdk\DataMapper\CategoryDataMapper;
 use Apiera\Sdk\DataMapper\DistributorDataMapper;
 use Apiera\Sdk\DataMapper\FileDataMapper;
 use Apiera\Sdk\Resource\AlternateIdentifierResource;
 use Apiera\Sdk\Resource\AttributeResource;
+use Apiera\Sdk\Resource\AttributeTermResource;
 use Apiera\Sdk\Resource\CategoryResource;
 use Apiera\Sdk\Resource\DistributorResource;
 use Apiera\Sdk\Resource\FileResource;
@@ -65,5 +67,12 @@ final readonly class ApieraSdk
         $dataMapper = new FileDataMapper();
 
         return new FileResource($this->client, $dataMapper);
+    }
+
+    public function attributeTerm(): AttributeTermResource
+    {
+        $dataMapper = new AttributeTermDataMapper();
+
+        return new AttributeTermResource($this->client, $dataMapper);
     }
 }

--- a/src/DTO/Request/AttributeTerm/AttributeTermRequest.php
+++ b/src/DTO/Request/AttributeTerm/AttributeTermRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\AttributeTerm;
+
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class AttributeTermRequest implements RequestInterface
+{
+    public function __construct(
+        private string $name,
+        private ?string $iri = null,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+        ];
+    }
+}

--- a/src/DTO/Request/AttributeTerm/AttributeTermRequest.php
+++ b/src/DTO/Request/AttributeTerm/AttributeTermRequest.php
@@ -14,6 +14,7 @@ final readonly class AttributeTermRequest implements RequestInterface
 {
     public function __construct(
         private string $name,
+        private ?string $attribute = null,
         private ?string $iri = null,
     ) {
     }
@@ -21,6 +22,11 @@ final readonly class AttributeTermRequest implements RequestInterface
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getAttribute(): ?string
+    {
+        return $this->attribute;
     }
 
     public function getIri(): ?string

--- a/src/DTO/Response/AttributeTerm/AttributeTermCollectionResponse.php
+++ b/src/DTO/Response/AttributeTerm/AttributeTermCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\AttributeTerm;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class AttributeTermCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<AttributeTermResponse>
+     */
+    public function getMembers(): array
+    {
+        /** @var array<AttributeTermResponse> $members */
+        $members = parent::getMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/AttributeTerm/AttributeTermResponse.php
+++ b/src/DTO/Response/AttributeTerm/AttributeTermResponse.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\AttributeTerm;
+
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class AttributeTermResponse extends AbstractResponse
+{
+    public function __construct(
+        string $id,
+        LdType $type,
+        Uuid $uuid,
+        DateTimeInterface $createdAt,
+        DateTimeInterface $updatedAt,
+        private string $name
+    ) {
+        parent::__construct(
+            $id,
+            $type,
+            $uuid,
+            $createdAt,
+            $updatedAt
+        );
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/DTO/Response/AttributeTerm/AttributeTermResponse.php
+++ b/src/DTO/Response/AttributeTerm/AttributeTermResponse.php
@@ -21,7 +21,9 @@ final readonly class AttributeTermResponse extends AbstractResponse
         Uuid $uuid,
         DateTimeInterface $createdAt,
         DateTimeInterface $updatedAt,
-        private string $name
+        private string $name,
+        private string $attribute,
+        private string $store
     ) {
         parent::__construct(
             $id,
@@ -35,5 +37,15 @@ final readonly class AttributeTermResponse extends AbstractResponse
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getAttribute(): string
+    {
+        return $this->attribute;
+    }
+
+    public function getStore(): string
+    {
+        return $this->store;
     }
 }

--- a/src/DataMapper/AttributeTermDataMapper.php
+++ b/src/DataMapper/AttributeTermDataMapper.php
@@ -59,7 +59,7 @@ final readonly class AttributeTermDataMapper implements DataMapperInterface
     {
         try {
             $members = array_map(
-                fn(array $attributeTerm): ResponseInterface =>
+                fn(array $attributeTerm): AttributeTermResponse =>
                 $this->fromResponse($attributeTerm),
                 $collectionResponseData['member']
             );
@@ -85,7 +85,7 @@ final readonly class AttributeTermDataMapper implements DataMapperInterface
     }
 
     /**
-     * @param \Apiera\Sdk\DTO\Request\Category\CategoryRequest $requestDto
+     * @param \Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest $requestDto
      *
      * @return array<string, mixed>
      */

--- a/src/DataMapper/AttributeTermDataMapper.php
+++ b/src/DataMapper/AttributeTermDataMapper.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DataMapper;
+
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermCollectionResponse;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\ClientException;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+use ValueError;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class AttributeTermDataMapper implements DataMapperInterface
+{
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     *
+     * @param array<string, mixed> $responseData
+     *
+     * @return AttributeTermResponse
+     */
+    public function fromResponse(array $responseData): ResponseInterface
+    {
+        try {
+            return new AttributeTermResponse(
+                id: $responseData['@id'],
+                type: LdType::from($responseData['@type']),
+                uuid: Uuid::fromString($responseData['uuid']),
+                createdAt: new DateTimeImmutable($responseData['createdAt']),
+                updatedAt: new DateTimeImmutable($responseData['updatedAt']),
+                name: $responseData['name'],
+            );
+        } catch (Throwable $exception) {
+            throw new ClientException(
+                message: 'Failed to map response data: ' . $exception->getMessage(),
+                previous: $exception
+            );
+        }
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     *
+     * @param array<string, mixed> $collectionResponseData
+     */
+    public function fromCollectionResponse(array $collectionResponseData): AttributeTermCollectionResponse
+    {
+        try {
+            $members = array_map(
+                fn(array $attributeTerm): ResponseInterface =>
+                $this->fromResponse($attributeTerm),
+                $collectionResponseData['member']
+            );
+
+            return new AttributeTermCollectionResponse(
+                context: $collectionResponseData['@context'],
+                id: $collectionResponseData['@id'],
+                type: LdType::from($collectionResponseData['@type']),
+                members: $members,
+                totalItems: $collectionResponseData['totalItems'],
+                view: $collectionResponseData['view'] ?? null,
+                firstPage: $collectionResponseData['firstPage'] ?? null,
+                lastPage: $collectionResponseData['lastPage'] ?? null,
+                nextPage: $collectionResponseData['nextPage'] ?? null,
+                previousPage: $collectionResponseData['previousPage'] ?? null,
+            );
+        } catch (ValueError $exception) {
+            throw new ClientException(
+                message: 'Invalid collection type: ' . $exception->getMessage(),
+                previous: $exception
+            );
+        }
+    }
+
+    /**
+     * @param AttributeTermRequest $requestDto
+     *
+     * @return array<string, mixed>
+     */
+    public function toRequestData(RequestInterface $requestDto): array
+    {
+        return $requestDto->toArray();
+    }
+}

--- a/src/DataMapper/AttributeTermDataMapper.php
+++ b/src/DataMapper/AttributeTermDataMapper.php
@@ -83,7 +83,7 @@ final readonly class AttributeTermDataMapper implements DataMapperInterface
     }
 
     /**
-     * @param AttributeTermRequest $requestDto
+     * @param \Apiera\Sdk\DTO\Request\Category\CategoryRequest $requestDto
      *
      * @return array<string, mixed>
      */

--- a/src/DataMapper/AttributeTermDataMapper.php
+++ b/src/DataMapper/AttributeTermDataMapper.php
@@ -39,6 +39,8 @@ final readonly class AttributeTermDataMapper implements DataMapperInterface
                 createdAt: new DateTimeImmutable($responseData['createdAt']),
                 updatedAt: new DateTimeImmutable($responseData['updatedAt']),
                 name: $responseData['name'],
+                attribute: $responseData['attribute'],
+                store: $responseData['store'],
             );
         } catch (Throwable $exception) {
             throw new ClientException(

--- a/src/Resource/AttributeTermResource.php
+++ b/src/Resource/AttributeTermResource.php
@@ -20,7 +20,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
  */
 final readonly class AttributeTermResource implements RequestResourceInterface
 {
-    private const string ENDPOINT = '/api/v1/attribute_terms';
+    private const string ENDPOINT = '/terms';
 
     public function __construct(
         private ClientInterface $client,
@@ -42,9 +42,13 @@ final readonly class AttributeTermResource implements RequestResourceInterface
             );
         }
 
+        if (!$request->getAttribute()) {
+            throw new InvalidRequestException('Attribute IRI is required for this operation');
+        }
+
         /** @var AttributeTermCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get(self::ENDPOINT, $params)
+            $this->client->get($request->getAttribute() . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -107,11 +111,15 @@ final readonly class AttributeTermResource implements RequestResourceInterface
             );
         }
 
+        if (!$request->getAttribute()) {
+            throw new InvalidRequestException('Attribute IRI is required for this operation');
+        }
+
         $requestData = $this->mapper->toRequestData($request);
 
         /** @var AttributeTermResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post(self::ENDPOINT, $requestData)
+            $this->client->post($request->getAttribute() . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/AttributeTermResource.php
+++ b/src/Resource/AttributeTermResource.php
@@ -32,10 +32,8 @@ final readonly class AttributeTermResource implements RequestResourceInterface
      * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
      * @throws InvalidRequestException
      */
-    public function find(
-        RequestInterface $request,
-        ?QueryParameters $params = null
-    ): AttributeTermCollectionResponse {
+    public function find(RequestInterface $request, ?QueryParameters $params = null): AttributeTermCollectionResponse
+    {
         if (!$request instanceof AttributeTermRequest) {
             throw new InvalidRequestException(
                 sprintf('Request must be an instance of %s', AttributeTermRequest::class)

--- a/src/Resource/AttributeTermResource.php
+++ b/src/Resource/AttributeTermResource.php
@@ -29,7 +29,7 @@ final readonly class AttributeTermResource implements RequestResourceInterface
     }
 
     /**
-     * @throws ClientExceptionInterface
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
      * @throws InvalidRequestException
      */
     public function find(
@@ -51,7 +51,7 @@ final readonly class AttributeTermResource implements RequestResourceInterface
     }
 
     /**
-     * @throws ClientExceptionInterface
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
      * @throws InvalidRequestException
      */
     public function findOneBy(RequestInterface $request, QueryParameters $params): AttributeTermResponse
@@ -72,7 +72,7 @@ final readonly class AttributeTermResource implements RequestResourceInterface
     }
 
     /**
-     * @throws ClientExceptionInterface
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
      * @throws InvalidRequestException
      */
     public function get(RequestInterface $request): AttributeTermResponse
@@ -96,7 +96,7 @@ final readonly class AttributeTermResource implements RequestResourceInterface
     }
 
     /**
-     * @throws ClientExceptionInterface
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
      * @throws InvalidRequestException
      */
     public function create(RequestInterface $request): AttributeTermResponse
@@ -118,7 +118,7 @@ final readonly class AttributeTermResource implements RequestResourceInterface
     }
 
     /**
-     * @throws ClientExceptionInterface
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
      * @throws InvalidRequestException
      */
     public function update(RequestInterface $request): AttributeTermResponse
@@ -144,7 +144,7 @@ final readonly class AttributeTermResource implements RequestResourceInterface
     }
 
     /**
-     * @throws ClientExceptionInterface
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
      * @throws InvalidRequestException
      */
     public function delete(RequestInterface $request): void

--- a/src/Resource/AttributeTermResource.php
+++ b/src/Resource/AttributeTermResource.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermCollectionResponse;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class AttributeTermResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/api/v1/attribute_terms';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function find(
+        RequestInterface $request,
+        ?QueryParameters $params = null
+    ): AttributeTermCollectionResponse {
+        if (!$request instanceof AttributeTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', AttributeTermRequest::class)
+            );
+        }
+
+        /** @var AttributeTermCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get(self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): AttributeTermResponse
+    {
+        if (!$request instanceof AttributeTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', AttributeTermRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getTotalItems() < 1) {
+            throw new InvalidRequestException('No attribute term found matching the given criteria');
+        }
+
+        return $collection->getMembers()[0];
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function get(RequestInterface $request): AttributeTermResponse
+    {
+        if (!$request instanceof AttributeTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', AttributeTermRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Attribute term IRI is required for this operation');
+        }
+
+        /** @var AttributeTermResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function create(RequestInterface $request): AttributeTermResponse
+    {
+        if (!$request instanceof AttributeTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', AttributeTermRequest::class)
+            );
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var AttributeTermResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post(self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function update(RequestInterface $request): AttributeTermResponse
+    {
+        if (!$request instanceof AttributeTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', AttributeTermRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Attribute term IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var AttributeTermResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof AttributeTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', AttributeTermRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Attribute Term IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/tests/Integration/Resource/AttributeTermResourceTest.php
+++ b/tests/Integration/Resource/AttributeTermResourceTest.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource;
+
+use Apiera\Sdk\ApieraSdk;
+use Apiera\Sdk\Configuration;
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class AttributeTermResourceTest extends TestCase
+{
+    private MockHandler $mockHandler;
+
+    /** @var array<int, array<string, mixed>>|\ArrayAccess<int, array<string, mixed>> */
+    private array|\ArrayAccess $requestHistory = [];
+    private ApieraSdk $sdk;
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testFindAttributeTermsFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $attributeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $termId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $storeId = '123e4567-e89b-12d3-a456-426614174000';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $attributeTermData = [
+            '@context' => '/api/contexts/AttributeTerm',
+            '@id' => '/api/v1/attributes/123/terms',
+            '@type' => 'Collection',
+            'member' => [[
+                '@id' => sprintf('%s/stores/%s/attributes/%s/terms/%s', $baseUrl, $storeId, $attributeId, $termId),
+                '@type' => 'AttributeTerm',
+                'uuid' => $termId,
+                'createdAt' => '2024-12-17T09:18:32+00:00',
+                'updatedAt' => '2024-12-17T09:18:32+00:00',
+                'name' => 'Example term',
+                'attribute' => sprintf('%s/stores/%s/attributes/%s', $baseUrl, $storeId, $attributeId),
+                'store' => sprintf('%s/stores/%s', $baseUrl, $storeId),
+            ]],
+            'totalItems' => 1,
+        ];
+        $this->mockHandler->append(new Response(200, [], json_encode($attributeTermData)));
+
+        $request = new AttributeTermRequest(
+            name: 'Example term',
+            attribute: sprintf('/api/v1/stores/%s/attributes/%s', $storeId, $attributeId)
+        );
+
+        $response = $this->sdk->attributeTerm()->find($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $attributeTermRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('GET', $attributeTermRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $attributeTermRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/ld+json', $attributeTermRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf('%s/stores/%s/attributes/%s/terms', $baseUrl, $storeId, $attributeId),
+            (string)$attributeTermRequest->getUri()
+        );
+
+        $this->assertEquals(1, $response->getTotalItems());
+        $this->assertCount(1, $response->getMembers());
+        $this->assertEquals('Example term', $response->getMembers()[0]->getName());
+        $this->assertEquals($termId, $response->getMembers()[0]->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testFindOneByAttributeTermFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $attributeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $termId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $storeId = '123e4567-e89b-12d3-a456-426614174000';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $attributeTermData = [
+            '@context' => '/api/contexts/AttributeTerm',
+            '@id' => '/api/v1/attributes/123/terms',
+            '@type' => 'Collection',
+            'member' => [[
+                '@id' => sprintf('%s/stores/%s/attributes/%s/terms/%s', $baseUrl, $storeId, $attributeId, $termId),
+                '@type' => 'AttributeTerm',
+                'uuid' => $termId,
+                'createdAt' => '2024-12-17T09:18:32+00:00',
+                'updatedAt' => '2024-12-17T09:18:32+00:00',
+                'name' => 'Example term',
+                'attribute' => sprintf('%s/stores/%s/attributes/%s', $baseUrl, $storeId, $attributeId),
+                'store' => sprintf('%s/stores/%s', $baseUrl, $storeId),
+            ]],
+            'totalItems' => 1,
+        ];
+        $this->mockHandler->append(new Response(200, [], json_encode($attributeTermData)));
+
+        $request = new AttributeTermRequest(
+            name: 'Example term',
+            attribute: sprintf('/api/v1/stores/%s/attributes/%s', $storeId, $attributeId)
+        );
+
+        $params = new QueryParameters(filters: ['name' => 'Example term']);
+        $response = $this->sdk->attributeTerm()->findOneBy($request, $params);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $attributeTermRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('GET', $attributeTermRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $attributeTermRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/ld+json', $attributeTermRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf(
+                '%s/stores/%s/attributes/%s/terms?filters%%5Bname%%5D=%s',
+                $baseUrl,
+                $storeId,
+                $attributeId,
+                rawurlencode('Example term')
+            ),
+            (string)$attributeTermRequest->getUri()
+        );
+
+        $this->assertEquals('Example term', $response->getName());
+        $this->assertEquals($termId, $response->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testCreateAttributeTermFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $attributeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $termId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $storeId = '123e4567-e89b-12d3-a456-426614174000';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $attributeTermData = [
+            '@id' => sprintf('%s/stores/%s/attributes/%s/terms/%s', $baseUrl, $storeId, $attributeId, $termId),
+            '@type' => 'AttributeTerm',
+            'uuid' => $termId,
+            'createdAt' => '2024-12-17T09:18:32+00:00',
+            'updatedAt' => '2024-12-17T09:18:32+00:00',
+            'name' => 'Example term',
+            'attribute' => sprintf('%s/stores/%s/attributes/%s', $baseUrl, $storeId, $attributeId),
+            'store' => sprintf('%s/stores/%s', $baseUrl, $storeId),
+        ];
+        $this->mockHandler->append(new Response(201, [], json_encode($attributeTermData)));
+
+        $request = new AttributeTermRequest(
+            name: 'Example term',
+            attribute: sprintf('/api/v1/stores/%s/attributes/%s', $storeId, $attributeId)
+        );
+
+        $response = $this->sdk->attributeTerm()->create($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $attributeTermRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('POST', $attributeTermRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $attributeTermRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/ld+json', $attributeTermRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf('%s/stores/%s/attributes/%s/terms', $baseUrl, $storeId, $attributeId),
+            (string)$attributeTermRequest->getUri()
+        );
+
+        $this->assertEquals('Example term', $response->getName());
+        $this->assertEquals($termId, $response->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testUpdateAttributeTermFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $attributeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $termId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $storeId = '123e4567-e89b-12d3-a456-426614174000';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $attributeTermData = [
+            '@id' => sprintf('%s/stores/%s/attributes/%s/terms/%s', $baseUrl, $storeId, $attributeId, $termId),
+            '@type' => 'AttributeTerm',
+            'uuid' => $termId,
+            'createdAt' => '2024-12-17T09:18:32+00:00',
+            'updatedAt' => '2024-12-17T09:18:32+00:00',
+            'name' => 'Updated term',
+            'attribute' => sprintf('%s/stores/%s/attributes/%s', $baseUrl, $storeId, $attributeId),
+            'store' => sprintf('%s/stores/%s', $baseUrl, $storeId),
+        ];
+        $this->mockHandler->append(new Response(200, [], json_encode($attributeTermData)));
+
+        $request = new AttributeTermRequest(
+            name: 'Updated term',
+            iri: sprintf('%s/stores/%s/attributes/%s/terms/%s', $baseUrl, $storeId, $attributeId, $termId)
+        );
+
+        $response = $this->sdk->attributeTerm()->update($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $attributeTermRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('PATCH', $attributeTermRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $attributeTermRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/merge-patch+json', $attributeTermRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf(
+                '%s/stores/%s/attributes/%s/terms/%s',
+                $baseUrl,
+                $storeId,
+                $attributeId,
+                $termId
+            ),
+            (string)$attributeTermRequest->getUri()
+        );
+
+        $this->assertEquals('Updated term', $response->getName());
+        $this->assertEquals($termId, $response->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testDeleteAttributeTermFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $this->mockHandler->append(new Response(204));
+
+        $attributeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $termId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $storeId = '123e4567-e89b-12d3-a456-426614174000';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $request = new AttributeTermRequest(
+            name: 'Example term',
+            iri: sprintf('%s/stores/%s/attributes/%s/terms/%s', $baseUrl, $storeId, $attributeId, $termId)
+        );
+
+        $this->sdk->attributeTerm()->delete($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $attributeTermRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('DELETE', $attributeTermRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $attributeTermRequest->getHeader('Authorization')[0]);
+        $this->assertEquals(
+            sprintf('%s/stores/%s/attributes/%s/terms/%s', $baseUrl, $storeId, $attributeId, $termId),
+            (string)$attributeTermRequest->getUri()
+        );
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     * @throws \Apiera\Sdk\Exception\ClientException
+     */
+    protected function setUp(): void
+    {
+        $this->mockHandler = new MockHandler();
+        $handlerStack = HandlerStack::create($this->mockHandler);
+
+        $history = Middleware::history($this->requestHistory);
+        $handlerStack->push($history);
+
+        $cacheItemMock = $this->createMock(CacheItemInterface::class);
+        $cacheItemMock->method('isHit')->willReturn(false);
+        $cacheItemMock->method('get')->willReturn(null);
+        $cacheItemMock->method('set')->willReturnSelf();
+        $cacheItemMock->method('expiresAfter')->willReturnSelf();
+
+        $cacheMock = $this->createMock(CacheItemPoolInterface::class);
+        $cacheMock->method('getItem')->willReturn($cacheItemMock);
+        $cacheMock->method('save')->willReturn(true);
+
+        $config = new Configuration(
+            baseUrl: 'https://api.test',
+            userAgent: 'Test/1.0',
+            oauthDomain: 'auth.test',
+            oauthClientId: 'test_client',
+            oauthClientSecret: 'test_secret',
+            oauthCookieSecret: 'test_cookie',
+            oauthAudience: 'test_audience',
+            oauthOrganizationId: 'test_org',
+            cache: $cacheMock,
+            timeout: 10,
+            debugMode: false,
+            options: [
+                'handler' => $handlerStack,
+            ]
+        );
+
+        $this->sdk = new ApieraSdk($config);
+    }
+}

--- a/tests/Unit/DTO/Request/AttributeTerm/AttributeTermRequestTest.php
+++ b/tests/Unit/DTO/Request/AttributeTerm/AttributeTermRequestTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\AttributeTerm;
+
+use Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeTermRequestTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $request = new AttributeTermRequest(name: '');
+
+        $this->assertInstanceOf(AttributeTermRequest::class, $request);
+        $this->assertInstanceOf(RequestInterface::class, $request);
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $request = new AttributeTermRequest(
+            name: '32gb',
+            attribute: '/api/v1/stores/123/attributes/321',
+            iri: '/api/v1/stores/123/attributes/456/terms/789'
+        );
+
+        $this->assertEquals('32gb', $request->getName());
+        $this->assertEquals('/api/v1/stores/123/attributes/321', $request->getAttribute());
+        $this->assertEquals('/api/v1/stores/123/attributes/456/terms/789', $request->getIri());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $request = new AttributeTermRequest(name: '32gb');
+
+        $this->assertEquals('32gb', $request->getName());
+        $this->assertNull($request->getAttribute());
+        $this->assertNull($request->getIri());
+    }
+
+    public function testToArray(): void
+    {
+        $request = new AttributeTermRequest(
+            name: '32gb',
+            attribute: '/api/v1/stores/123/attributes/321',
+            iri: '/api/v1/stores/123/attributes/456/terms/789'
+        );
+
+        $array = $request->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayNotHasKey('attribute', $array);
+        $this->assertArrayNotHasKey('iri', $array);
+        $this->assertEquals(['name' => '32gb'], $array);
+    }
+}

--- a/tests/Unit/DTO/Response/AttributeTerm/AttributeTermCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/AttributeTerm/AttributeTermCollectionResponseTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\AttributeTerm;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermCollectionResponse;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDCollectionInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+final class AttributeTermCollectionResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new AttributeTermCollectionResponse(
+            context: '',
+            id: '',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertInstanceOf(AttributeTermCollectionResponse::class, $response);
+        $this->assertInstanceOf(AbstractCollectionResponse::class, $response);
+        $this->assertInstanceOf(JsonLDCollectionInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(AttributeTermCollectionResponse::class);
+
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $attributeTermResponse = new AttributeTermResponse(
+            id: '/api/v1/stores/321/attributes/123/terms/456',
+            type: LdType::AttributeTerm,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Example term',
+            attribute: '/api/v1/stores/321/attributes/123',
+            store: '/api/v1/stores/321'
+        );
+
+        $response = new AttributeTermCollectionResponse(
+            context: '/api/v1/contexts/AttributeTerm',
+            id: '/api/v1/attributes/123/terms',
+            type: LdType::Collection,
+            members: [$attributeTermResponse],
+            totalItems: 1,
+            view: '/api/v1/attributes/123/terms?page=1',
+            firstPage: '/api/v1/attributes/123/terms?page=1',
+            lastPage: '/api/v1/attributes/123/terms?page=1',
+            nextPage: null,
+            previousPage: null
+        );
+
+        $this->assertEquals('/api/v1/contexts/AttributeTerm', $response->getLdContext());
+        $this->assertEquals('/api/v1/attributes/123/terms', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertCount(1, $response->getMembers());
+        $this->assertInstanceOf(AttributeTermResponse::class, $response->getMembers()[0]);
+        $this->assertEquals(1, $response->getTotalItems());
+        $this->assertEquals('/api/v1/attributes/123/terms?page=1', $response->getView());
+        $this->assertEquals('/api/v1/attributes/123/terms?page=1', $response->getFirstPage());
+        $this->assertEquals('/api/v1/attributes/123/terms?page=1', $response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $response = new AttributeTermCollectionResponse(
+            context: '/api/v1/contexts/AttributeTerm',
+            id: '/api/v1/attributes/123/terms',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertEquals('/api/v1/contexts/AttributeTerm', $response->getLdContext());
+        $this->assertEquals('/api/v1/attributes/123/terms', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertEmpty($response->getMembers());
+        $this->assertEquals(0, $response->getTotalItems());
+        $this->assertNull($response->getView());
+        $this->assertNull($response->getFirstPage());
+        $this->assertNull($response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+}

--- a/tests/Unit/DTO/Response/AttributeTerm/AttributeTermResponseTest.php
+++ b/tests/Unit/DTO/Response/AttributeTerm/AttributeTermResponseTest.php
@@ -24,7 +24,9 @@ final class AttributeTermResponseTest extends TestCase
             uuid: Uuid::v4(),
             createdAt: new DateTimeImmutable(),
             updatedAt: new DateTimeImmutable(),
-            name: ''
+            name: '',
+            attribute: '',
+            store: ''
         );
 
         $this->assertInstanceOf(AttributeTermResponse::class, $response);

--- a/tests/Unit/DTO/Response/AttributeTerm/AttributeTermResponseTest.php
+++ b/tests/Unit/DTO/Response/AttributeTerm/AttributeTermResponseTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\AttributeTerm;
+
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDInterface;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+final class AttributeTermResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new AttributeTermResponse(
+            id: '',
+            type: LdType::AttributeTerm,
+            uuid: Uuid::v4(),
+            createdAt: new DateTimeImmutable(),
+            updatedAt: new DateTimeImmutable(),
+            name: ''
+        );
+
+        $this->assertInstanceOf(AttributeTermResponse::class, $response);
+        $this->assertInstanceOf(AbstractResponse::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(JsonLDInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(AttributeTermResponse::class);
+
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testPropertiesAreReadonly(): void
+    {
+        $reflection = new ReflectionClass(AttributeTermResponse::class);
+        $properties = $reflection->getProperties();
+
+        foreach ($properties as $property) {
+            $this->assertTrue($property->isReadonly(), sprintf('Property %s should be readonly', $property->getName()));
+        }
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $response = new AttributeTermResponse(
+            id: '/api/v1/stores/321/attributes/123/terms/456',
+            type: LdType::AttributeTerm,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Example term',
+            attribute: '/api/v1/stores/321/attributes/123',
+            store: '/api/v1/stores/321'
+        );
+
+        $this->assertEquals('/api/v1/stores/321/attributes/123/terms/456', $response->getLdId());
+        $this->assertEquals(LdType::AttributeTerm, $response->getLdType());
+        $this->assertTrue(Uuid::isValid($response->getUuid()->toRfc4122()));
+        $this->assertEquals('bfd2639c-7793-426a-a413-ea262e582208', $response->getUuid()->toRfc4122());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getCreatedAt());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getUpdatedAt());
+        $this->assertEquals('Example term', $response->getName());
+        $this->assertEquals('/api/v1/stores/321/attributes/123', $response->getAttribute());
+        $this->assertEquals('/api/v1/stores/321', $response->getStore());
+    }
+}

--- a/tests/Unit/DataMapper/AttributeTermDataMapperTest.php
+++ b/tests/Unit/DataMapper/AttributeTermDataMapperTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DataMapper;
+
+use Apiera\Sdk\DataMapper\AttributeTermDataMapper;
+use Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermCollectionResponse;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\ClientException;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class AttributeTermDataMapperTest extends TestCase
+{
+    private AttributeTermDataMapper $mapper;
+
+    /** @var array<string, mixed> */
+    private array $sampleResponseData;
+
+    /** @var array<string, mixed> */
+    private array $sampleCollectionData;
+    private AttributeTermRequest $sampleRequest;
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromResponseMapsAllFieldsCorrectly(): void
+    {
+        $result = $this->mapper->fromResponse($this->sampleResponseData);
+
+        $this->assertInstanceOf(AttributeTermResponse::class, $result);
+        $this->assertEquals('/api/v1/stores/321/attributes/123/terms/456', $result->getLdId());
+        $this->assertEquals(LdType::AttributeTerm, $result->getLdType());
+        $this->assertEquals(Uuid::fromString('123e4567-e89b-12d3-a456-426614174000'), $result->getUuid());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getCreatedAt());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getUpdatedAt());
+        $this->assertEquals('Example term', $result->getName());
+        $this->assertEquals('/api/v1/stores/321/attributes/123', $result->getAttribute());
+        $this->assertEquals('/api/v1/stores/321', $result->getStore());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseMapsDataCorrectly(): void
+    {
+        $result = $this->mapper->fromCollectionResponse($this->sampleCollectionData);
+
+        $this->assertInstanceOf(AttributeTermCollectionResponse::class, $result);
+        $this->assertEquals('/api/contexts/AttributeTerm', $result->getLdContext());
+        $this->assertEquals('/api/v1/attributes/123/terms', $result->getLdId());
+        $this->assertEquals(LdType::Collection, $result->getLdType());
+        $this->assertEquals(1, $result->getTotalItems());
+        $this->assertCount(1, $result->getMembers());
+        $this->assertInstanceOf(AttributeTermResponse::class, $result->getMembers()[0]);
+        $this->assertEquals('/api/v1/attributes/123/terms?page=1', $result->getView());
+        $this->assertEquals('/api/v1/attributes/123/terms?page=1', $result->getFirstPage());
+        $this->assertEquals('/api/v1/attributes/123/terms?page=1', $result->getLastPage());
+        $this->assertNull($result->getNextPage());
+        $this->assertNull($result->getPreviousPage());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromResponseThrowsExceptionForInvalidDate(): void
+    {
+        $data = $this->sampleResponseData;
+        $data['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromResponse($data);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseThrowsExceptionForInvalidType(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['@type'] = 'InvalidType';
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Invalid collection type');
+        $this->mapper->fromCollectionResponse($data);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseHandlesEmptyCollection(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'] = [];
+        $data['totalItems'] = 0;
+
+        $result = $this->mapper->fromCollectionResponse($data);
+
+        $this->assertEmpty($result->getMembers());
+        $this->assertEquals(0, $result->getTotalItems());
+    }
+
+    public function testToRequestDataIncludesRequiredFields(): void
+    {
+        $result = $this->mapper->toRequestData($this->sampleRequest);
+
+        $expected = [
+            'name' => 'Example term',
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseWithInvalidMemberThrowsException(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'][0]['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromCollectionResponse($data);
+    }
+
+    protected function setUp(): void
+    {
+        $this->mapper = new AttributeTermDataMapper();
+
+        $this->sampleResponseData = [
+            '@id' => '/api/v1/stores/321/attributes/123/terms/456',
+            '@type' => 'AttributeTerm',
+            'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'createdAt' => '2025-01-01T00:00:00+00:00',
+            'updatedAt' => '2025-01-01T00:00:00+00:00',
+            'name' => 'Example term',
+            'attribute' => '/api/v1/stores/321/attributes/123',
+            'store' => '/api/v1/stores/321',
+        ];
+
+        $this->sampleCollectionData = [
+            '@context' => '/api/contexts/AttributeTerm',
+            '@id' => '/api/v1/attributes/123/terms',
+            '@type' => 'Collection',
+            'member' => [$this->sampleResponseData],
+            'totalItems' => 1,
+            'view' => '/api/v1/attributes/123/terms?page=1',
+            'firstPage' => '/api/v1/attributes/123/terms?page=1',
+            'lastPage' => '/api/v1/attributes/123/terms?page=1',
+            'nextPage' => null,
+            'previousPage' => null,
+        ];
+
+        $this->sampleRequest = new AttributeTermRequest(
+            name: 'Example term',
+            attribute: '/api/v1/stores/321/attributes/123'
+        );
+    }
+}

--- a/tests/Unit/Resource/AttributeTermResourceTest.php
+++ b/tests/Unit/Resource/AttributeTermResourceTest.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Resource;
+
+use Apiera\Sdk\Client;
+use Apiera\Sdk\DataMapper\AttributeTermDataMapper;
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermCollectionResponse;
+use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Resource\AttributeTermResource;
+use DateTimeImmutable;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class AttributeTermResourceTest extends TestCase
+{
+    private Client|MockObject $clientMock;
+    private AttributeTermDataMapper|MockObject $mapperMock;
+    private AttributeTermResource $resource;
+    private AttributeTermRequest $request;
+    private AttributeTermResponse $response;
+    private AttributeTermCollectionResponse $collectionResponse;
+
+    /** @var array<string, mixed> */
+    private array $mockResponseData;
+
+    /** @var array<string, mixed> */
+    private array $mockCollectionData;
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFindRequiresAttributeIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->find(new AttributeTermRequest(name: 'Example term'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testFindReturnsCollection(): void
+    {
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->clientMock->expects($this->once())
+            ->method('get')
+            ->with('/api/v1/stores/321/attributes/123/terms')
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($this->mockCollectionData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromCollectionResponse')
+            ->with($this->mockCollectionData)
+            ->willReturn($this->collectionResponse);
+
+        $result = $this->resource->find($this->request);
+        $this->assertSame($this->collectionResponse, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testFindOneByReturnsFirstResult(): void
+    {
+        $params = new QueryParameters(filters: ['name' => 'Example term']);
+
+        $this->clientMock->expects($this->once())
+            ->method('get')
+            ->with('/api/v1/stores/321/attributes/123/terms')
+            ->willReturn($this->createMock(ResponseInterface::class));
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->willReturn($this->mockCollectionData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromCollectionResponse')
+            ->willReturn($this->collectionResponse);
+
+        $result = $this->resource->findOneBy($this->request, $params);
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testFindOneByThrowsExceptionWhenEmpty(): void
+    {
+        $emptyCollectionData = [
+            '@context' => '/api/contexts/AttributeTerm',
+            '@id' => '/api/v1/stores/321/attributes/123/terms',
+            '@type' => 'Collection',
+            'member' => [],
+            'totalItems' => 0,
+        ];
+
+        $emptyCollection = new AttributeTermCollectionResponse(
+            context: '/api/contexts/AttributeTerm',
+            id: '/api/v1/stores/321/attributes/123/terms',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->clientMock->method('get')
+            ->willReturn($this->createMock(ResponseInterface::class));
+
+        $this->clientMock->method('decodeResponse')
+            ->willReturn($emptyCollectionData);
+
+        $this->mapperMock->method('fromCollectionResponse')
+            ->willReturn($emptyCollection);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->findOneBy($this->request, new QueryParameters());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testGetRequiresIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->get(new AttributeTermRequest(name: 'Example term'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testGetReturnsAttributeTerm(): void
+    {
+        $request = new AttributeTermRequest(
+            name: 'Example term',
+            iri: '/api/v1/stores/321/attributes/123/terms/456'
+        );
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->clientMock->expects($this->once())
+            ->method('get')
+            ->with('/api/v1/stores/321/attributes/123/terms/456')
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($this->mockResponseData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromResponse')
+            ->with($this->mockResponseData)
+            ->willReturn($this->response);
+
+        $result = $this->resource->get($request);
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testCreateRequiresAttributeIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->create(new AttributeTermRequest(name: 'Example term'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testCreateAttributeTerm(): void
+    {
+        $requestData = [
+            'name' => 'Example term',
+        ];
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->mapperMock->expects($this->once())
+            ->method('toRequestData')
+            ->with($this->request)
+            ->willReturn($requestData);
+
+        $this->clientMock->expects($this->once())
+            ->method('post')
+            ->with('/api/v1/stores/321/attributes/123/terms', $requestData)
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($this->mockResponseData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromResponse')
+            ->with($this->mockResponseData)
+            ->willReturn($this->response);
+
+        $result = $this->resource->create($this->request);
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testUpdateRequiresIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->update(new AttributeTermRequest(name: 'Example term'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testUpdateAttributeTerm(): void
+    {
+        $request = new AttributeTermRequest(
+            name: 'Updated term',
+            iri: '/api/v1/stores/321/attributes/123/terms/456'
+        );
+
+        $requestData = ['name' => 'Updated term'];
+        $updatedResponseData = array_merge($this->mockResponseData, ['name' => 'Updated term']);
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->mapperMock->expects($this->once())
+            ->method('toRequestData')
+            ->with($request)
+            ->willReturn($requestData);
+
+        $this->clientMock->expects($this->once())
+            ->method('patch')
+            ->with('/api/v1/stores/321/attributes/123/terms/456', $requestData)
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($updatedResponseData);
+
+        $updatedResponse = new AttributeTermResponse(
+            id: '/api/v1/stores/321/attributes/123/terms/456',
+            type: LdType::AttributeTerm,
+            uuid: Uuid::fromString('f47ac10b-58cc-4372-a567-0e02b2c3d479'),
+            createdAt: new DateTimeImmutable('2024-01-25T12:00:00+00:00'),
+            updatedAt: new DateTimeImmutable('2024-01-25T12:00:00+00:00'),
+            name: 'Updated term',
+            attribute: '/api/v1/stores/321/attributes/123',
+            store: '/api/v1/stores/321'
+        );
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromResponse')
+            ->with($updatedResponseData)
+            ->willReturn($updatedResponse);
+
+        $result = $this->resource->update($request);
+        $this->assertSame($updatedResponse, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testDeleteRequiresIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->delete(new AttributeTermRequest(name: 'Example term'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testDeleteAttributeTerm(): void
+    {
+        $request = new AttributeTermRequest(
+            name: 'Example term',
+            iri: '/api/v1/stores/321/attributes/123/terms/456'
+        );
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->clientMock->expects($this->once())
+            ->method('delete')
+            ->with('/api/v1/stores/321/attributes/123/terms/456')
+            ->willReturn($responseMock);
+
+        $this->resource->delete($request);
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    protected function setUp(): void
+    {
+        $this->clientMock = $this->createMock(Client::class);
+        $this->mapperMock = $this->createMock(AttributeTermDataMapper::class);
+        $this->resource = new AttributeTermResource($this->clientMock, $this->mapperMock);
+
+        // Setup realistic test data
+        $this->request = new AttributeTermRequest(
+            name: 'Example term',
+            attribute: '/api/v1/stores/321/attributes/123'
+        );
+
+        $uuid = Uuid::fromString('f47ac10b-58cc-4372-a567-0e02b2c3d479');
+        $createdAt = new DateTimeImmutable('2024-01-25T12:00:00+00:00');
+        $updatedAt = new DateTimeImmutable('2024-01-25T12:00:00+00:00');
+
+        $this->response = new AttributeTermResponse(
+            id: '/api/v1/stores/321/attributes/123/terms/456',
+            type: LdType::AttributeTerm,
+            uuid: $uuid,
+            createdAt: $createdAt,
+            updatedAt: $updatedAt,
+            name: 'Example term',
+            attribute: '/api/v1/stores/321/attributes/123',
+            store: '/api/v1/stores/321'
+        );
+
+        $this->mockResponseData = [
+            '@id' => '/api/v1/stores/321/attributes/123/terms/456',
+            '@type' => 'AttributeTerm',
+            'uuid' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            'name' => 'Example term',
+            'attribute' => '/api/v1/stores/321/attributes/123',
+            'store' => '/api/v1/stores/321',
+            'createdAt' => '2024-01-25T12:00:00+00:00',
+            'updatedAt' => '2024-01-25T12:00:00+00:00',
+        ];
+
+        $this->mockCollectionData = [
+            '@context' => '/api/contexts/AttributeTerm',
+            '@id' => '/api/v1/stores/321/attributes/123/terms',
+            '@type' => 'Collection',
+            'member' => [$this->mockResponseData],
+            'totalItems' => 1,
+            'view' => '/api/v1/attributes/123/terms?page=1',
+            'firstPage' => '/api/v1/attributes/123/terms?page=1',
+            'lastPage' => '/api/v1/attributes/123/terms?page=1',
+        ];
+
+        $this->collectionResponse = new AttributeTermCollectionResponse(
+            context: '/api/contexts/AttributeTerm',
+            id: '/api/v1/stores/321/attributes/123/terms',
+            type: LdType::Collection,
+            members: [$this->response],
+            totalItems: 1,
+            view: '/api/v1/attributes/123/terms?page=1',
+            firstPage: '/api/v1/attributes/123/terms?page=1',
+            lastPage: '/api/v1/attributes/123/terms?page=1',
+        );
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces several enhancements and new components for handling attribute term data via the API. The changes include:

- **DTOs**: Added `AttributeTermRequest`, `AttributeTermResponse`, and `AttributeTermCollectionResponse` classes for managing and encapsulating attribute term data.
- **Resource Class**: Introduced `AttributeTermResource` to handle CRUD operations and API requests related to attribute terms. Includes validations for request types and IRIs.
- **Data Mapping**: Added `AttributeTermDataMapper` to transform API responses into DTOs and vice versa, with support for single and collection responses.
- **Refinements**: 
  - Updated docblocks in `AttributeTermDataMapper` to use a more specific request DTO class for parameter typing.
  - Updated all `@throws` annotations to use fully qualified class names, ensuring clarity and maintaining consistency.

These additions and enhancements improve code structure, maintainability, and robustness when interacting with attribute term data.