### PR TITLE
Add Property management support and examples to SDK

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,6 +9,7 @@
     - [Distributors](#distributors)
     - [Files](#files)
     - [Brands](#brands)
+    - [Properties](#properties)
 
 ---
 
@@ -481,4 +482,102 @@ $requestObject = new \Apiera\Sdk\DTO\Request\Brand\BrandRequest(
 );
 
 $responseObject = $sdk->brand()->update($requestObject);
+```
+
+## Properties
+
+### Find Properties
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\Property\PropertyRequest(
+    store: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d' // Pass the store IRI
+);
+
+$responseObject = $sdk->property()->find($requestObject);
+```
+
+---
+
+### Find Properties with Filter and Pagination
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\Property\PropertyRequest(
+    store: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d' // Pass the store IRI
+);
+
+$queryParamObject = new \Apiera\Sdk\DTO\QueryParameters(
+    filters: ['name' => 'some property name'] // Add filters as needed
+);
+
+$responseObject = $sdk->property()->find($requestObject, $queryParamObject);
+```
+
+---
+
+### Search a Single Property
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\Property\PropertyRequest(
+    store: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d' // Pass the store IRI
+);
+
+$queryParamObject = new \Apiera\Sdk\DTO\QueryParameters(
+    filters: ['name' => 'Some property name'] // Define search criteria
+);
+
+try {
+    $responseObject = $sdk->property()->findOneBy($requestObject, $queryParamObject);
+} catch (\Apiera\Sdk\Exception\InvalidRequestException) {
+    // Handle the case when the property is not found
+}
+```
+
+---
+
+### Find a Property
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\Property\PropertyRequest(
+    iri: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/properties/520413a8-509a-4048-96e6-81751e315c5d2' // Use the property IRI
+);
+
+$responseObject = $sdk->property()->get($requestObject);
+```
+
+---
+
+### Create a Property
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\Property\PropertyRequest(
+    name: 'Some property name',
+    store: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d' // Pass the store IRI
+);
+
+$responseObject = $sdk->property()->create($requestObject);
+```
+
+---
+
+### Update a Property
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\Property\PropertyRequest(
+    name: 'Some new property name',
+    iri: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/properties/520413a8-509a-4048-96e6-81751e315c5d2' // Use the property IRI
+);
+
+$responseObject = $sdk->property()->update($requestObject);
+```
+
+---
+
+### Delete a Property
+
+```php
+$requestObject = new \Apiera\Sdk\DTO\Request\Property\PropertyRequest(
+    iri: '/api/v1/stores/520413a8-509a-4048-96e6-81751e315c5d/properties/520413a8-509a-4048-96e6-81751e315c5d2' // Use the property IRI
+);
+
+$sdk->property()->delete($requestObject);
 ```

--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -10,12 +10,14 @@ use Apiera\Sdk\DataMapper\BrandDataMapper;
 use Apiera\Sdk\DataMapper\CategoryDataMapper;
 use Apiera\Sdk\DataMapper\DistributorDataMapper;
 use Apiera\Sdk\DataMapper\FileDataMapper;
+use Apiera\Sdk\DataMapper\PropertyDataMapper;
 use Apiera\Sdk\Resource\AlternateIdentifierResource;
 use Apiera\Sdk\Resource\AttributeResource;
 use Apiera\Sdk\Resource\BrandResource;
 use Apiera\Sdk\Resource\CategoryResource;
 use Apiera\Sdk\Resource\DistributorResource;
 use Apiera\Sdk\Resource\FileResource;
+use Apiera\Sdk\Resource\PropertyResource;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
@@ -74,5 +76,12 @@ final readonly class ApieraSdk
         $dataMapper = new FileDataMapper();
 
         return new FileResource($this->client, $dataMapper);
+    }
+
+    public function property(): PropertyResource
+    {
+        $dataMapper = new PropertyDataMapper();
+
+        return new PropertyResource($this->client, $dataMapper);
     }
 }

--- a/src/DTO/Request/Property/PropertyRequest.php
+++ b/src/DTO/Request/Property/PropertyRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\Property;
+
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class PropertyRequest implements RequestInterface
+{
+    /**
+     * @param string $name The property name
+     * @param string|null $store The property store iri
+     * @param string|null $iri The property iri
+     */
+    public function __construct(
+        private string $name,
+        private ?string $store = null,
+        private ?string $iri = null
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getStore(): ?string
+    {
+        return $this->store;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+        ];
+    }
+}

--- a/src/DTO/Response/Property/PropertyCollectionResponse.php
+++ b/src/DTO/Response/Property/PropertyCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Property;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class PropertyCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<PropertyResponse>
+     */
+    public function getMembers(): array
+    {
+        /** @var array<PropertyResponse> $members */
+        $members = parent::getMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/Property/PropertyResponse.php
+++ b/src/DTO/Response/Property/PropertyResponse.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Property;
+
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class PropertyResponse extends AbstractResponse
+{
+    /**
+     * @param string $name The property name
+     * @param string $store The store iri
+     */
+    public function __construct(
+        string $id,
+        LdType $type,
+        Uuid $uuid,
+        DateTimeInterface $createdAt,
+        DateTimeInterface $updatedAt,
+        private string $name,
+        private string $store,
+    ) {
+        parent::__construct(
+            $id,
+            $type,
+            $uuid,
+            $createdAt,
+            $updatedAt
+        );
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getStore(): string
+    {
+        return $this->store;
+    }
+}

--- a/src/DataMapper/PropertyDataMapper.php
+++ b/src/DataMapper/PropertyDataMapper.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DataMapper;
+
+use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
+use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\ClientException;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+use ValueError;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final class PropertyDataMapper implements DataMapperInterface
+{
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     *
+     * @param array<string, mixed> $responseData
+     *
+     * @return PropertyResponse
+     */
+    public function fromResponse(array $responseData): ResponseInterface
+    {
+        try {
+            return new PropertyResponse(
+                id: $responseData['@id'],
+                type: LdType::from($responseData['@type']),
+                uuid: Uuid::fromString($responseData['uuid']),
+                createdAt: new DateTimeImmutable($responseData['createdAt']),
+                updatedAt: new DateTimeImmutable($responseData['updatedAt']),
+                name: $responseData['name'],
+                store: $responseData['store'],
+            );
+        } catch (Throwable $exception) {
+            throw new ClientException(
+                message: 'Failed to map response data: ' . $exception->getMessage(),
+                previous: $exception
+            );
+        }
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     *
+     * @param array<string, mixed> $collectionResponseData
+     */
+    public function fromCollectionResponse(array $collectionResponseData): PropertyCollectionResponse
+    {
+        try {
+            return new PropertyCollectionResponse(
+                context: $collectionResponseData['@context'],
+                id: $collectionResponseData['@id'],
+                type: LdType::from($collectionResponseData['@type']),
+                members: array_map(
+                    fn(array $property): PropertyResponse => $this->fromResponse($property),
+                    $collectionResponseData['member']
+                ),
+                totalItems: $collectionResponseData['totalItems'],
+                view: $collectionResponseData['view'] ?? null,
+                firstPage: $collectionResponseData['firstPage'] ?? null,
+                lastPage: $collectionResponseData['lastPage'] ?? null,
+                nextPage: $collectionResponseData['nextPage'] ?? null,
+                previousPage: $collectionResponseData['previousPage'] ?? null,
+            );
+        } catch (ValueError $exception) {
+            throw new ClientException(
+                message: 'Invalid collection type: ' . $exception->getMessage(),
+                previous: $exception
+            );
+        }
+    }
+
+    /**
+     * @param \Apiera\Sdk\DTO\Request\Property\PropertyRequest $requestDto
+     *
+     * @return array<string, mixed>
+     */
+    public function toRequestData(RequestInterface $requestDto): array
+    {
+        return $requestDto->toArray();
+    }
+}

--- a/src/Resource/PropertyResource.php
+++ b/src/Resource/PropertyResource.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\Property\PropertyRequest;
+use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
+use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class PropertyResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/properties';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function find(RequestInterface $request, ?QueryParameters $params = null): PropertyCollectionResponse
+    {
+        if (!$request instanceof PropertyRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyRequest::class)
+            );
+        }
+
+        if (!$request->getStore()) {
+            throw new InvalidRequestException('Store IRI is required for this operation');
+        }
+
+        /** @var PropertyCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): PropertyResponse
+    {
+        if (!$request instanceof PropertyRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getTotalItems() < 1) {
+            throw new InvalidRequestException('No property found matching the given criteria');
+        }
+
+        return $collection->getMembers()[0];
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function get(RequestInterface $request): PropertyResponse
+    {
+        if (!$request instanceof PropertyRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Property IRI is required for this operation');
+        }
+
+        /** @var PropertyResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function create(RequestInterface $request): PropertyResponse
+    {
+        if (!$request instanceof PropertyRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyRequest::class)
+            );
+        }
+
+        if (!$request->getStore()) {
+            throw new InvalidRequestException('Store IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var PropertyResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function update(RequestInterface $request): PropertyResponse
+    {
+        if (!$request instanceof PropertyRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Property IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var PropertyResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws InvalidRequestException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof PropertyRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Property IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/tests/Integration/Resource/PropertyResourceTest.php
+++ b/tests/Integration/Resource/PropertyResourceTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource;
+
+use Apiera\Sdk\ApieraSdk;
+use Apiera\Sdk\Configuration;
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\Property\PropertyRequest;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class PropertyResourceTest extends TestCase
+{
+    private MockHandler $mockHandler;
+
+    /** @var array<int, array<string, mixed>>|\ArrayAccess<int, array<string, mixed>> */
+    private array|\ArrayAccess $requestHistory = [];
+    private ApieraSdk $sdk;
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testFindPropertiesFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $storeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $propertyId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $propertyData = [
+            '@context' => '/api/v1/contexts/Property',
+            '@id' => '/api/v1/stores/123/properties',
+            '@type' => 'Collection',
+            'member' => [[
+                '@id' => sprintf('%s/stores/%s/properties/%s', $baseUrl, $storeId, $propertyId),
+                '@type' => 'Property',
+                'uuid' => $propertyId,
+                'createdAt' => '2024-12-17T09:18:32+00:00',
+                'updatedAt' => '2024-12-17T09:18:32+00:00',
+                'name' => 'Test property',
+                'store' => sprintf('%s/stores/%s', $baseUrl, $storeId),
+            ]],
+            'totalItems' => 1,
+        ];
+        $this->mockHandler->append(new Response(200, [], json_encode($propertyData)));
+
+        $request = new PropertyRequest(
+            name: 'Test property',
+            store: sprintf('/api/v1/stores/%s', $storeId)
+        );
+
+        $response = $this->sdk->property()->find($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $propertyRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('GET', $propertyRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $propertyRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/ld+json', $propertyRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf('%s/stores/%s/properties', $baseUrl, $storeId),
+            (string)$propertyRequest->getUri()
+        );
+
+        $this->assertEquals(1, $response->getTotalItems());
+        $this->assertCount(1, $response->getMembers());
+        $this->assertEquals('Test property', $response->getMembers()[0]->getName());
+        $this->assertEquals($propertyId, $response->getMembers()[0]->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testFindOneByPropertyFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $storeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $propertyId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $propertyData = [
+            '@context' => '/api/v1/contexts/Property',
+            '@id' => '/api/v1/stores/123/properties',
+            '@type' => 'Collection',
+            'member' => [[
+                '@id' => sprintf('%s/stores/%s/properties/%s', $baseUrl, $storeId, $propertyId),
+                '@type' => 'Property',
+                'uuid' => $propertyId,
+                'createdAt' => '2024-12-17T09:18:32+00:00',
+                'updatedAt' => '2024-12-17T09:18:32+00:00',
+                'name' => 'Test property',
+                'store' => sprintf('%s/stores/%s', $baseUrl, $storeId),
+            ]],
+            'totalItems' => 1,
+        ];
+        $this->mockHandler->append(new Response(200, [], json_encode($propertyData)));
+
+        $request = new PropertyRequest(
+            name: 'Test property',
+            store: sprintf('api/v1/stores/%s', $storeId),
+        );
+
+        $params = new QueryParameters(filters: ['name' => 'Test property']);
+        $response = $this->sdk->property()->findOneBy($request, $params);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $propertyRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('GET', $propertyRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $propertyRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/ld+json', $propertyRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf(
+                '%s/stores/%s/properties?filters%%5Bname%%5D=%s',
+                $baseUrl,
+                $storeId,
+                rawurlencode('Test property')
+            ),
+            (string)$propertyRequest->getUri()
+        );
+
+        $this->assertEquals('Test property', $response->getName());
+        $this->assertEquals($propertyId, $response->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testCreatePropertyFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $storeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $propertyId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $propertyData = [
+            '@id' => sprintf('%s/stores/%s/properties/%s', $baseUrl, $storeId, $propertyId),
+            '@type' => 'Property',
+            'uuid' => $propertyId,
+            'createdAt' => '2024-12-17T09:18:32+00:00',
+            'updatedAt' => '2024-12-17T09:18:32+00:00',
+            'name' => 'Test property',
+            'store' => sprintf('%s/stores/%s', $baseUrl, $storeId),
+        ];
+        $this->mockHandler->append(new Response(201, [], json_encode($propertyData)));
+
+        $request = new PropertyRequest(
+            name: 'Test property',
+            store: sprintf('api/v1/stores/%s', $storeId),
+        );
+
+        $response = $this->sdk->property()->create($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $propertyRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('POST', $propertyRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $propertyRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/ld+json', $propertyRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf('%s/stores/%s/properties', $baseUrl, $storeId),
+            (string)$propertyRequest->getUri()
+        );
+
+        $this->assertEquals('Test property', $response->getName());
+        $this->assertEquals($propertyId, $response->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testUpdatePropertyFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $storeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $propertyId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $propertyData = [
+            '@id' => sprintf('%s/stores/%s/properties/%s', $baseUrl, $storeId, $propertyId),
+            '@type' => 'Property',
+            'uuid' => $propertyId,
+            'createdAt' => '2024-12-17T09:18:32+00:00',
+            'updatedAt' => '2024-12-17T09:18:32+00:00',
+            'name' => 'Updated property',
+            'store' => sprintf('%s/stores/%s', $baseUrl, $storeId),
+        ];
+        $this->mockHandler->append(new Response(200, [], json_encode($propertyData)));
+
+        $request = new PropertyRequest(
+            name: 'Updated property',
+            iri: sprintf('%s/stores/%s/properties/%s', $baseUrl, $storeId, $propertyId)
+        );
+
+        $response = $this->sdk->property()->update($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $propertyRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('PATCH', $propertyRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $propertyRequest->getHeader('Authorization')[0]);
+        $this->assertEquals('application/merge-patch+json', $propertyRequest->getHeader('Content-Type')[0]);
+        $this->assertEquals(
+            sprintf(
+                '%s/stores/%s/properties/%s',
+                $baseUrl,
+                $storeId,
+                $propertyId
+            ),
+            (string)$propertyRequest->getUri()
+        );
+
+        $this->assertEquals('Updated property', $response->getName());
+        $this->assertEquals($propertyId, $response->getUuid()->toString());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    public function testDeletePropertyFlow(): void
+    {
+        $this->mockHandler->append(new Response(200, [], json_encode([
+            'access_token' => 'test_token',
+            'expires_in' => 3600,
+        ])));
+
+        $this->mockHandler->append(new Response(204));
+
+        $storeId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+        $propertyId = 'e548e809-2ab1-4832-8dd9-f67115da61fb';
+        $baseUrl = 'https://api.test/api/v1';
+
+        $request = new PropertyRequest(
+            name: 'Test property',
+            iri: sprintf('%s/stores/%s/properties/%s', $baseUrl, $storeId, $propertyId)
+        );
+
+        $this->sdk->property()->delete($request);
+
+        $this->assertCount(2, $this->requestHistory);
+
+        $authRequest = $this->requestHistory[0]['request'];
+        $this->assertEquals('POST', $authRequest->getMethod());
+        $this->assertEquals('https://auth.test/oauth/token', (string)$authRequest->getUri());
+
+        $propertyRequest = $this->requestHistory[1]['request'];
+        $this->assertEquals('DELETE', $propertyRequest->getMethod());
+        $this->assertEquals('Bearer test_token', $propertyRequest->getHeader('Authorization')[0]);
+        $this->assertEquals(
+            sprintf('%s/stores/%s/properties/%s', $baseUrl, $storeId, $propertyId),
+            (string)$propertyRequest->getUri()
+        );
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     * @throws \Apiera\Sdk\Exception\ClientException
+     */
+    protected function setUp(): void
+    {
+        $this->mockHandler = new MockHandler();
+        $handlerStack = HandlerStack::create($this->mockHandler);
+
+        $history = Middleware::history($this->requestHistory);
+        $handlerStack->push($history);
+
+        $cacheItemMock = $this->createMock(CacheItemInterface::class);
+        $cacheItemMock->method('isHit')->willReturn(false);
+        $cacheItemMock->method('get')->willReturn(null);
+        $cacheItemMock->method('set')->willReturnSelf();
+        $cacheItemMock->method('expiresAfter')->willReturnSelf();
+
+        $cacheMock = $this->createMock(CacheItemPoolInterface::class);
+        $cacheMock->method('getItem')->willReturn($cacheItemMock);
+        $cacheMock->method('save')->willReturn(true);
+
+        $config = new Configuration(
+            baseUrl: 'https://api.test',
+            userAgent: 'Test/1.0',
+            oauthDomain: 'auth.test',
+            oauthClientId: 'test_client',
+            oauthClientSecret: 'test_secret',
+            oauthCookieSecret: 'test_cookie',
+            oauthAudience: 'test_audience',
+            oauthOrganizationId: 'test_org',
+            cache: $cacheMock,
+            timeout: 10,
+            debugMode: false,
+            options: [
+                'handler' => $handlerStack,
+            ]
+        );
+
+        $this->sdk = new ApieraSdk($config);
+    }
+}

--- a/tests/Unit/DTO/Request/Property/PropertyRequestTest.php
+++ b/tests/Unit/DTO/Request/Property/PropertyRequestTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\Property;
+
+use Apiera\Sdk\DTO\Request\Property\PropertyRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use PHPUnit\Framework\TestCase;
+
+final class PropertyRequestTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $request = new PropertyRequest('');
+
+        $this->assertInstanceOf(PropertyRequest::class, $request);
+        $this->assertInstanceOf(RequestInterface::class, $request);
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $request = new PropertyRequest(
+            name: 'Example Property',
+            store: '/api/v1/store/123',
+            iri: '/api/v1/stores/123/properties/321'
+        );
+
+        $this->assertEquals('Example Property', $request->getName());
+        $this->assertEquals('/api/v1/store/123', $request->getStore());
+        $this->assertEquals('/api/v1/stores/123/properties/321', $request->getIri());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $request = new PropertyRequest(name: 'Example Property');
+
+        $this->assertEquals('Example Property', $request->getName());
+        $this->assertNull($request->getStore());
+        $this->assertNull($request->getIri());
+    }
+
+    public function testToArray(): void
+    {
+        $request = new PropertyRequest(
+            name: 'Example Property',
+            store: '/api/v1/store/123',
+            iri: '/api/v1/stores/123/properties/321'
+        );
+
+        $array = $request->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('name', $array);
+        $this->assertArrayNotHasKey('store', $array);
+        $this->assertArrayNotHasKey('iri', $array);
+
+        $this->assertEquals('Example Property', $array['name']);
+        $this->assertEquals(['name' => 'Example Property'], $array);
+    }
+}

--- a/tests/Unit/DTO/Response/Property/PropertyCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Property/PropertyCollectionResponseTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Property;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
+use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDCollectionInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+final class PropertyCollectionResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new PropertyCollectionResponse(
+            context: '',
+            id: '',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertInstanceOf(PropertyCollectionResponse::class, $response);
+        $this->assertInstanceOf(AbstractCollectionResponse::class, $response);
+        $this->assertInstanceOf(JsonLDCollectionInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(PropertyCollectionResponse::class);
+
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $propertyResponse = new PropertyResponse(
+            id: '/api/v1/stores/321/properties/123',
+            type: LdType::Property,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Example property',
+            store: '/api/v1/stores/321'
+        );
+
+        $response = new PropertyCollectionResponse(
+            context: '/api/v1/contexts/Property',
+            id: '/api/v1/stores/321/properties',
+            type: LdType::Collection,
+            members: [$propertyResponse],
+            totalItems: 1,
+            view: '/api/v1/stores/321/properties?page=1',
+            firstPage: '/api/v1/stores/321/properties?page=1',
+            lastPage: '/api/v1/stores/321/properties?page=1',
+            nextPage: null,
+            previousPage: null
+        );
+
+        $this->assertEquals('/api/v1/contexts/Property', $response->getLdContext());
+        $this->assertEquals('/api/v1/stores/321/properties', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertCount(1, $response->getMembers());
+        $this->assertInstanceOf(PropertyResponse::class, $response->getMembers()[0]);
+        $this->assertEquals(1, $response->getTotalItems());
+        $this->assertEquals('/api/v1/stores/321/properties?page=1', $response->getView());
+        $this->assertEquals('/api/v1/stores/321/properties?page=1', $response->getFirstPage());
+        $this->assertEquals('/api/v1/stores/321/properties?page=1', $response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+
+    public function testConstructorWithMinimalParameters(): void
+    {
+        $response = new PropertyCollectionResponse(
+            context: '/api/v1/contexts/Property',
+            id: '/api/v1/stores/321/properties',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->assertEquals('/api/v1/contexts/Property', $response->getLdContext());
+        $this->assertEquals('/api/v1/stores/321/properties', $response->getLdId());
+        $this->assertEquals(LdType::Collection, $response->getLdType());
+        $this->assertEmpty($response->getMembers());
+        $this->assertEquals(0, $response->getTotalItems());
+        $this->assertNull($response->getView());
+        $this->assertNull($response->getFirstPage());
+        $this->assertNull($response->getLastPage());
+        $this->assertNull($response->getNextPage());
+        $this->assertNull($response->getPreviousPage());
+    }
+}

--- a/tests/Unit/DTO/Response/Property/PropertyResponseTest.php
+++ b/tests/Unit/DTO/Response/Property/PropertyResponseTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Property;
+
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\JsonLDInterface;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\Uid\Uuid;
+
+final class PropertyResponseTest extends TestCase
+{
+    public function testInstanceOf(): void
+    {
+        $response = new PropertyResponse(
+            id: '',
+            type: LdType::Attribute,
+            uuid: Uuid::v4(),
+            createdAt: new DateTimeImmutable(),
+            updatedAt: new DateTimeImmutable(),
+            name: '',
+            store: ''
+        );
+
+        $this->assertInstanceOf(PropertyResponse::class, $response);
+        $this->assertInstanceOf(AbstractResponse::class, $response);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertInstanceOf(JsonLDInterface::class, $response);
+    }
+
+    public function testClassIsCorrectlyDefined(): void
+    {
+        $reflection = new ReflectionClass(PropertyResponse::class);
+
+        $this->assertTrue($reflection->isReadonly(), 'Class should be readonly');
+    }
+
+    public function testPropertiesAreReadonly(): void
+    {
+        $reflection = new ReflectionClass(PropertyResponse::class);
+        $properties = $reflection->getProperties();
+
+        foreach ($properties as $property) {
+            $this->assertTrue($property->isReadonly(), sprintf('Property %s should be readonly', $property->getName()));
+        }
+    }
+
+    public function testConstructorAndGetters(): void
+    {
+        $response = new PropertyResponse(
+            id: '/api/v1/stores/321/properties/123',
+            type: LdType::Property,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Example property',
+            store: '/api/v1/stores/321'
+        );
+
+        $this->assertEquals('/api/v1/stores/321/properties/123', $response->getLdId());
+        $this->assertEquals(LdType::Property, $response->getLdType());
+        $this->assertTrue(Uuid::isValid($response->getUuid()->toRfc4122()));
+        $this->assertEquals('bfd2639c-7793-426a-a413-ea262e582208', $response->getUuid()->toRfc4122());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getCreatedAt());
+        $this->assertEquals(new DateTimeImmutable('2021-01-01 00:00:00'), $response->getUpdatedAt());
+        $this->assertEquals('Example property', $response->getName());
+        $this->assertEquals('/api/v1/stores/321', $response->getStore());
+    }
+}

--- a/tests/Unit/DataMapper/PropertyDataMapperTest.php
+++ b/tests/Unit/DataMapper/PropertyDataMapperTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DataMapper;
+
+use Apiera\Sdk\DataMapper\PropertyDataMapper;
+use Apiera\Sdk\DTO\Request\Property\PropertyRequest;
+use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
+use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\ClientException;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class PropertyDataMapperTest extends TestCase
+{
+    private PropertyDataMapper $mapper;
+
+    /** @var array<string, mixed> */
+    private array $sampleResponseData;
+
+    /** @var array<string, mixed> */
+    private array $sampleCollectionData;
+    private PropertyRequest $sampleRequest;
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromResponseMapsAllFieldsCorrectly(): void
+    {
+        $result = $this->mapper->fromResponse($this->sampleResponseData);
+
+        $this->assertInstanceOf(PropertyResponse::class, $result);
+        $this->assertEquals('/api/v1/stores/123/properties/456', $result->getLdId());
+        $this->assertEquals(LdType::Property, $result->getLdType());
+        $this->assertEquals(Uuid::fromString('123e4567-e89b-12d3-a456-426614174000'), $result->getUuid());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getCreatedAt());
+        $this->assertInstanceOf(DateTimeImmutable::class, $result->getUpdatedAt());
+        $this->assertEquals('Test property', $result->getName());
+        $this->assertEquals('/api/v1/stores/123', $result->getStore());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromResponseThrowsExceptionForInvalidDate(): void
+    {
+        $data = $this->sampleResponseData;
+        $data['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromResponse($data);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseThrowsExceptionForInvalidType(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['@type'] = 'InvalidType';
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Invalid collection type');
+        $this->mapper->fromCollectionResponse($data);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseMapsDataCorrectly(): void
+    {
+        $result = $this->mapper->fromCollectionResponse($this->sampleCollectionData);
+
+        $this->assertInstanceOf(PropertyCollectionResponse::class, $result);
+        $this->assertEquals('/api/contexts/Property', $result->getLdContext());
+        $this->assertEquals('/api/v1/stores/123/properties', $result->getLdId());
+        $this->assertEquals(LdType::Collection, $result->getLdType());
+        $this->assertEquals(1, $result->getTotalItems());
+        $this->assertCount(1, $result->getMembers());
+        $this->assertInstanceOf(PropertyResponse::class, $result->getMembers()[0]);
+        $this->assertEquals('/api/v1/stores/123/properties?page=1', $result->getView());
+        $this->assertEquals('/api/v1/stores/123/properties?page=1', $result->getFirstPage());
+        $this->assertEquals('/api/v1/stores/123/properties?page=1', $result->getLastPage());
+        $this->assertNull($result->getNextPage());
+        $this->assertNull($result->getPreviousPage());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseHandlesEmptyCollection(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'] = [];
+        $data['totalItems'] = 0;
+
+        $result = $this->mapper->fromCollectionResponse($data);
+
+        $this->assertEmpty($result->getMembers());
+        $this->assertEquals(0, $result->getTotalItems());
+    }
+
+    public function testToRequestDataIncludesRequiredFields(): void
+    {
+        $result = $this->mapper->toRequestData($this->sampleRequest);
+
+        $expected = [
+            'name' => 'Test property',
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFromCollectionResponseWithInvalidMemberThrowsException(): void
+    {
+        $data = $this->sampleCollectionData;
+        $data['member'][0]['createdAt'] = 'invalid-date';
+
+        $this->expectException(ClientException::class);
+        $this->mapper->fromCollectionResponse($data);
+    }
+
+    protected function setUp(): void
+    {
+        $this->mapper = new PropertyDataMapper();
+
+        $this->sampleResponseData = [
+            '@id' => '/api/v1/stores/123/properties/456',
+            '@type' => 'Property',
+            'uuid' => '123e4567-e89b-12d3-a456-426614174000',
+            'createdAt' => '2025-01-01T00:00:00+00:00',
+            'updatedAt' => '2025-01-01T00:00:00+00:00',
+            'name' => 'Test property',
+            'store' => '/api/v1/stores/123',
+        ];
+
+        $this->sampleCollectionData = [
+            '@context' => '/api/contexts/Property',
+            '@id' => '/api/v1/stores/123/properties',
+            '@type' => 'Collection',
+            'member' => [$this->sampleResponseData],
+            'totalItems' => 1,
+            'view' => '/api/v1/stores/123/properties?page=1',
+            'firstPage' => '/api/v1/stores/123/properties?page=1',
+            'lastPage' => '/api/v1/stores/123/properties?page=1',
+            'nextPage' => null,
+            'previousPage' => null,
+        ];
+
+        $this->sampleRequest = new PropertyRequest(
+            name: 'Test property',
+            store: '/api/stores/123'
+        );
+    }
+}

--- a/tests/Unit/Resource/PropertyResourceTest.php
+++ b/tests/Unit/Resource/PropertyResourceTest.php
@@ -1,0 +1,374 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Resource;
+
+use Apiera\Sdk\Client;
+use Apiera\Sdk\DataMapper\PropertyDataMapper;
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\Property\PropertyRequest;
+use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
+use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Resource\PropertyResource;
+use DateTimeImmutable;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\Uid\Uuid;
+
+final class PropertyResourceTest extends TestCase
+{
+    private Client|MockObject $clientMock;
+    private PropertyDataMapper|MockObject $mapperMock;
+    private PropertyResource $resource;
+    private PropertyRequest $request;
+    private PropertyResponse $response;
+    private PropertyCollectionResponse $collectionResponse;
+
+    /** @var array<string, mixed> */
+    private array $mockResponseData;
+
+    /** @var array<string, mixed> */
+    private array $mockCollectionData;
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testFindRequiresStoreIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->find(new PropertyRequest(name: 'Test property'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testFindReturnsCollection(): void
+    {
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->clientMock->expects($this->once())
+            ->method('get')
+            ->with('/api/v1/stores/123/properties')
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($this->mockCollectionData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromCollectionResponse')
+            ->with($this->mockCollectionData)
+            ->willReturn($this->collectionResponse);
+
+        $result = $this->resource->find($this->request);
+        $this->assertSame($this->collectionResponse, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testFindOneByReturnsFirstResult(): void
+    {
+        $params = new QueryParameters(filters: ['name' => 'Test property']);
+
+        $this->clientMock->expects($this->once())
+            ->method('get')
+            ->with('/api/v1/stores/123/properties')
+            ->willReturn($this->createMock(ResponseInterface::class));
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->willReturn($this->mockCollectionData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromCollectionResponse')
+            ->willReturn($this->collectionResponse);
+
+        $result = $this->resource->findOneBy($this->request, $params);
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testFindOneByThrowsExceptionWhenEmpty(): void
+    {
+        $emptyCollectionData = [
+            '@context' => '/api/v1/contexts/Property',
+            '@id' => '/api/v1/properties',
+            '@type' => 'Collection',
+            'member' => [],
+            'totalItems' => 0,
+        ];
+
+        $emptyCollection = new PropertyCollectionResponse(
+            context: '/api/v1/contexts/Property',
+            id: '/api/v1/properties',
+            type: LdType::Collection,
+            members: [],
+            totalItems: 0
+        );
+
+        $this->clientMock->method('get')
+            ->willReturn($this->createMock(ResponseInterface::class));
+
+        $this->clientMock->method('decodeResponse')
+            ->willReturn($emptyCollectionData);
+
+        $this->mapperMock->method('fromCollectionResponse')
+            ->willReturn($emptyCollection);
+
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->findOneBy($this->request, new QueryParameters());
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testGetRequiresIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->get(new PropertyRequest(name: 'Test property'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testGetReturnsProperty(): void
+    {
+        $request = new PropertyRequest(
+            name: 'Test property',
+            iri: '/api/v1/stores/123/properties/456'
+        );
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->clientMock->expects($this->once())
+            ->method('get')
+            ->with('/api/v1/stores/123/properties/456')
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($this->mockResponseData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromResponse')
+            ->with($this->mockResponseData)
+            ->willReturn($this->response);
+
+        $result = $this->resource->get($request);
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testCreateRequiresStoreIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->create(new PropertyRequest(name: 'Test property'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testCreateProperty(): void
+    {
+        $requestData = [
+            'name' => 'Test property',
+        ];
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->mapperMock->expects($this->once())
+            ->method('toRequestData')
+            ->with($this->request)
+            ->willReturn($requestData);
+
+        $this->clientMock->expects($this->once())
+            ->method('post')
+            ->with('/api/v1/stores/123/properties', $requestData)
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($this->mockResponseData);
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromResponse')
+            ->with($this->mockResponseData)
+            ->willReturn($this->response);
+
+        $result = $this->resource->create($this->request);
+        $this->assertSame($this->response, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testUpdateRequiresIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->update(new PropertyRequest(name: 'Test property'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testUpdateProperty(): void
+    {
+        $request = new PropertyRequest(
+            name: 'Updated property',
+            iri: '/api/v1/stores/123/properties/456'
+        );
+
+        $requestData = ['name' => 'Updated property'];
+        $updatedResponseData = array_merge($this->mockResponseData, ['name' => 'Updated property']);
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->mapperMock->expects($this->once())
+            ->method('toRequestData')
+            ->with($request)
+            ->willReturn($requestData);
+
+        $this->clientMock->expects($this->once())
+            ->method('patch')
+            ->with('/api/v1/stores/123/properties/456', $requestData)
+            ->willReturn($responseMock);
+
+        $this->clientMock->expects($this->once())
+            ->method('decodeResponse')
+            ->with($responseMock)
+            ->willReturn($updatedResponseData);
+
+        $updatedResponse = new PropertyResponse(
+            id: '/api/v1/stores/123/properties/456',
+            type: LdType::Property,
+            uuid: Uuid::fromString('f47ac10b-58cc-4372-a567-0e02b2c3d479'),
+            createdAt: new DateTimeImmutable('2024-01-25T12:00:00+00:00'),
+            updatedAt: new DateTimeImmutable('2024-01-25T12:00:00+00:00'),
+            name: 'Updated property',
+            store: '/api/v1/stores/123'
+        );
+
+        $this->mapperMock->expects($this->once())
+            ->method('fromResponse')
+            ->with($updatedResponseData)
+            ->willReturn($updatedResponse);
+
+        $result = $this->resource->update($request);
+        $this->assertSame($updatedResponse, $result);
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     */
+    public function testDeleteRequiresIri(): void
+    {
+        $this->expectException(InvalidRequestException::class);
+        $this->resource->delete(new PropertyRequest(name: 'Test property'));
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Interface\ClientExceptionInterface
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    public function testDeleteProperty(): void
+    {
+        $request = new PropertyRequest(
+            name: 'Test property',
+            iri: '/api/v1/stores/123/properties/456'
+        );
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+
+        $this->clientMock->expects($this->once())
+            ->method('delete')
+            ->with('/api/v1/stores/123/properties/456')
+            ->willReturn($responseMock);
+
+        $this->resource->delete($request);
+    }
+
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    protected function setUp(): void
+    {
+        $this->clientMock = $this->createMock(Client::class);
+        $this->mapperMock = $this->createMock(PropertyDataMapper::class);
+        $this->resource = new PropertyResource($this->clientMock, $this->mapperMock);
+
+        // Setup realistic test data
+        $this->request = new PropertyRequest(
+            name: 'Test property',
+            store: '/api/v1/stores/123'
+        );
+
+        $uuid = Uuid::fromString('f47ac10b-58cc-4372-a567-0e02b2c3d479');
+        $createdAt = new DateTimeImmutable('2024-01-25T12:00:00+00:00');
+        $updatedAt = new DateTimeImmutable('2024-01-25T12:00:00+00:00');
+
+        $this->response = new PropertyResponse(
+            id: '/api/v1/stores/123/properties/456',
+            type: LdType::Property,
+            uuid: $uuid,
+            createdAt: $createdAt,
+            updatedAt: $updatedAt,
+            name: 'Test property',
+            store: '/api/v1/stores/123'
+        );
+
+        $this->mockResponseData = [
+            '@id' => '/api/v1/stores/123/properties/456',
+            '@type' => 'Property',
+            'uuid' => 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            'name' => 'Test property',
+            'store' => '/api/v1/stores/123',
+            'createdAt' => '2024-01-25T12:00:00+00:00',
+            'updatedAt' => '2024-01-25T12:00:00+00:00',
+        ];
+
+        $this->mockCollectionData = [
+            '@context' => '/api/v1/contexts/Property',
+            '@id' => '/api/v1/stores/123/properties',
+            '@type' => 'Collection',
+            'member' => [$this->mockResponseData],
+            'totalItems' => 1,
+            'view' => '/api/v1/stores/123/properties?page=1',
+            'firstPage' => '/api/v1/stores/123/properties?page=1',
+            'lastPage' => '/api/v1/stores/123/properties?page=1',
+        ];
+
+        $this->collectionResponse = new PropertyCollectionResponse(
+            context: '/api/v1/contexts/Property',
+            id: '/api/v1/stores/123/properties',
+            type: LdType::Collection,
+            members: [$this->response],
+            totalItems: 1,
+            view: '/api/v1/stores/123/properties?page=1',
+            firstPage: '/api/v1/stores/123/properties?page=1',
+            lastPage: '/api/v1/stores/123/properties?page=1'
+        );
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces comprehensive support for managing properties within the SDK. Key changes include:

- **`PropertyResource` Implementation**: Added CRUD operations (`find`, `findOneBy`, `get`, `create`, `update`, `delete`), along with corresponding unit and integration tests to ensure reliability and proper integration flow.
- **Data Transformation Tools**: Introduced `PropertyDataMapper` for request and response data mapping, and added unit tests for validation.
- **DTO Classes**:
  - Added `PropertyRequest` with methods for serialization and data handling.
  - Implemented `PropertyResponse` to handle readonly property data.
- **Collection Handling**: Added `PropertyCollectionResponse` to facilitate handling of collections of properties reliably.
- **SDK Integration**: Introduced the `property()` method in `ApieraSdk`, enabling access to the newly implemented `PropertyResource`.
- **Documentation Updates**: Enhanced the documentation with code examples for property management, including CRUD operations, filtering, and pagination.

This pull request ensures a scalable, well-documented, and test-covered solution for property management in the SDK.