### PR TITLE
Add Organization DTOs and unit tests

### DIFF
--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -13,6 +13,7 @@ use Apiera\Sdk\Resource\CategoryResource;
 use Apiera\Sdk\Resource\DistributorResource;
 use Apiera\Sdk\Resource\FileResource;
 use Apiera\Sdk\Resource\InventoryLocationResource;
+use Apiera\Sdk\Resource\OrganizationResource;
 use Apiera\Sdk\Resource\ProductResource;
 use Apiera\Sdk\Resource\PropertyResource;
 
@@ -101,5 +102,12 @@ final readonly class ApieraSdk
         $dataMapper = new ReflectionAttributeDataMapper();
 
         return new InventoryLocationResource($this->client, $dataMapper);
+    }
+
+    public function organization(): OrganizationResource
+    {
+        $dataMapper = new ReflectionAttributeDataMapper();
+
+        return new OrganizationResource($this->client, $dataMapper);
     }
 }

--- a/src/DTO/Request/Organization/OrganizationRequest.php
+++ b/src/DTO/Request/Organization/OrganizationRequest.php
@@ -14,37 +14,24 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
  */
 final readonly class OrganizationRequest implements RequestInterface
 {
-    /**
-     * @param string[] $alternateIdentifiers
-     */
     public function __construct(
         #[RequestField('name')]
-        private string $name,
+        private ?string $name = null,
         #[RequestField('extId')]
-        private string $extId,
-        #[RequestField('alternateIdentifiers')]
-        private array $alternateIdentifiers = [],
+        private ?string $extId = null,
         #[SkipRequest]
         private ?string $iri = null
     ) {
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getExtId(): string
+    public function getExtId(): ?string
     {
         return $this->extId;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAlternateIdentifiers(): array
-    {
-        return $this->alternateIdentifiers;
     }
 
     public function getIri(): ?string
@@ -60,7 +47,6 @@ final readonly class OrganizationRequest implements RequestInterface
         return [
             'name' => $this->name,
             'extId' => $this->extId,
-            'alternateIdentifiers' => $this->alternateIdentifiers,
         ];
     }
 }

--- a/src/DTO/Request/Organization/OrganizationRequest.php
+++ b/src/DTO/Request/Organization/OrganizationRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\Organization;
+
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\SkipRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class OrganizationRequest implements RequestInterface
+{
+    /**
+     * @param string[] $alternateIdentifiers
+     */
+    public function __construct(
+        #[RequestField('name')]
+        private string $name,
+        #[RequestField('extId')]
+        private string $extId,
+        #[RequestField('alternateIdentifiers')]
+        private array $alternateIdentifiers = [],
+        #[SkipRequest]
+        private ?string $iri = null
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getExtId(): string
+    {
+        return $this->extId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAlternateIdentifiers(): array
+    {
+        return $this->alternateIdentifiers;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'extId' => $this->extId,
+            'alternateIdentifiers' => $this->alternateIdentifiers,
+        ];
+    }
+}

--- a/src/DTO/Response/Organization/OrganizationCollectionResponse.php
+++ b/src/DTO/Response/Organization/OrganizationCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Organization;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class OrganizationCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<OrganizationResponse>
+     */
+    public function getLdMembers(): array
+    {
+        /** @var array<OrganizationResponse> $members */
+        $members = parent::getLdMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/Organization/OrganizationResponse.php
+++ b/src/DTO/Response/Organization/OrganizationResponse.php
@@ -20,9 +20,6 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class OrganizationResponse extends AbstractResponse
 {
-    /**
-     * @param string[] $alternateIdentifiers
-     */
     public function __construct(
         #[JsonLdResponseField('@id')]
         private string $ldId,
@@ -35,11 +32,9 @@ final readonly class OrganizationResponse extends AbstractResponse
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
         #[ResponseField('name')]
-        private string $name,
+        private ?string $name = null,
         #[ResponseField('extId')]
-        private string $extId,
-        #[ResponseField('alternateIdentifiers')]
-        private array $alternateIdentifiers = [],
+        private ?string $extId = null,
     ) {
         parent::__construct(
             $this->ldId,
@@ -75,21 +70,13 @@ final readonly class OrganizationResponse extends AbstractResponse
         return $this->updatedAt;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getExtId(): string
+    public function getExtId(): ?string
     {
         return $this->extId;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getAlternateIdentifiers(): array
-    {
-        return $this->alternateIdentifiers;
     }
 }

--- a/src/DTO/Response/Organization/OrganizationResponse.php
+++ b/src/DTO/Response/Organization/OrganizationResponse.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Organization;
+
+use Apiera\Sdk\Attribute\JsonLdResponseField;
+use Apiera\Sdk\Attribute\ResponseField;
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Transformer\DateTimeTransformer;
+use Apiera\Sdk\Transformer\LdTypeTransformer;
+use Apiera\Sdk\Transformer\UuidTransformer;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class OrganizationResponse extends AbstractResponse
+{
+    /**
+     * @param string[] $alternateIdentifiers
+     */
+    public function __construct(
+        #[JsonLdResponseField('@id')]
+        private string $ldId,
+        #[JsonLdResponseField('@type', LdTypeTransformer::class)]
+        private LdType $ldType,
+        #[ResponseField('uuid', UuidTransformer::class)]
+        private Uuid $uuid,
+        #[ResponseField('createdAt', DateTimeTransformer::class)]
+        private DateTimeInterface $createdAt,
+        #[ResponseField('updatedAt', DateTimeTransformer::class)]
+        private DateTimeInterface $updatedAt,
+        #[ResponseField('name')]
+        private string $name,
+        #[ResponseField('extId')]
+        private string $extId,
+        #[ResponseField('alternateIdentifiers')]
+        private array $alternateIdentifiers = [],
+    ) {
+        parent::__construct(
+            $this->ldId,
+            $this->ldType,
+            $this->uuid,
+            $this->createdAt,
+            $this->updatedAt
+        );
+    }
+
+    public function getLdId(): string
+    {
+        return $this->ldId;
+    }
+
+    public function getLdType(): LdType
+    {
+        return $this->ldType;
+    }
+
+    public function getUuid(): Uuid
+    {
+        return $this->uuid;
+    }
+
+    public function getCreatedAt(): DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getExtId(): string
+    {
+        return $this->extId;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAlternateIdentifiers(): array
+    {
+        return $this->alternateIdentifiers;
+    }
+}

--- a/src/DTO/Response/Organization/OrganizationResponse.php
+++ b/src/DTO/Response/Organization/OrganizationResponse.php
@@ -32,9 +32,9 @@ final readonly class OrganizationResponse extends AbstractResponse
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
         #[ResponseField('name')]
-        private ?string $name = null,
+        private string $name,
         #[ResponseField('extId')]
-        private ?string $extId = null,
+        private string $extId,
     ) {
         parent::__construct(
             $this->ldId,
@@ -70,12 +70,12 @@ final readonly class OrganizationResponse extends AbstractResponse
         return $this->updatedAt;
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getExtId(): ?string
+    public function getExtId(): string
     {
         return $this->extId;
     }

--- a/src/Enum/LdType.php
+++ b/src/Enum/LdType.php
@@ -20,6 +20,8 @@ use Apiera\Sdk\DTO\Response\File\FileCollectionResponse;
 use Apiera\Sdk\DTO\Response\File\FileResponse;
 use Apiera\Sdk\DTO\Response\InventoryLocation\InventoryLocationCollectionResponse;
 use Apiera\Sdk\DTO\Response\InventoryLocation\InventoryLocationResponse;
+use Apiera\Sdk\DTO\Response\Organization\OrganizationCollectionResponse;
+use Apiera\Sdk\DTO\Response\Organization\OrganizationResponse;
 use Apiera\Sdk\DTO\Response\Product\ProductCollectionResponse;
 use Apiera\Sdk\DTO\Response\Product\ProductResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
@@ -100,10 +102,13 @@ enum LdType: string
                 ResponseType::Single->value => InventoryLocationResponse::class,
                 ResponseType::Collection->value => InventoryLocationCollectionResponse::class,
             ],
+            self::Organization => [
+                ResponseType::Single->value => OrganizationResponse::class,
+                ResponseType::Collection->value => OrganizationCollectionResponse::class,
+            ],
             self::Integration,
             self::IntegrationResourceMap,
             self::Inventory,
-            self::Organization,
             self::PropertyTerm,
             self::Sku,
             self::Store,

--- a/src/Resource/OrganizationResource.php
+++ b/src/Resource/OrganizationResource.php
@@ -162,5 +162,7 @@ final readonly class OrganizationResource implements RequestResourceInterface
         if (!$request->getIri()) {
             throw new InvalidRequestException('Organization IRI is required for this operation');
         }
+
+        $this->client->delete($request->getIri());
     }
 }

--- a/src/Resource/OrganizationResource.php
+++ b/src/Resource/OrganizationResource.php
@@ -21,7 +21,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
  */
 final readonly class OrganizationResource implements RequestResourceInterface
 {
-    private const string ENDPOINT = '/organizations';
+    private const string ENDPOINT = '/api/v1/organizations';
 
     public function __construct(
         private ClientInterface $client,
@@ -66,7 +66,7 @@ final readonly class OrganizationResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No Organization found matching the given criteria');
+            throw new InvalidRequestException('No organization found matching the given criteria');
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/OrganizationResource.php
+++ b/src/Resource/OrganizationResource.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\Organization\OrganizationRequest;
+use Apiera\Sdk\DTO\Response\Organization\OrganizationCollectionResponse;
+use Apiera\Sdk\DTO\Response\Organization\OrganizationResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class OrganizationResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/organizations';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function find(RequestInterface $request, ?QueryParameters $params = null): OrganizationCollectionResponse
+    {
+        if (!$request instanceof OrganizationRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', OrganizationRequest::class)
+            );
+        }
+
+        /** @var OrganizationCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get(self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): OrganizationResponse
+    {
+        if (!$request instanceof OrganizationRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', OrganizationRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getLdTotalItems() < 1) {
+            throw new InvalidRequestException('No Organization found matching the given criteria');
+        }
+
+        return $collection->getLdMembers()[0];
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function get(RequestInterface $request): Organizationresponse
+    {
+        if (!$request instanceof OrganizationRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', OrganizationRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Organization IRI is required for this operation');
+        }
+
+        /** @var OrganizationResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function create(RequestInterface $request): OrganizationResponse
+    {
+        if (!$request instanceof OrganizationRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', OrganizationRequest::class)
+            );
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var OrganizationResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post(self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function update(RequestInterface $request): ResponseInterface
+    {
+        if (!$request instanceof OrganizationRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', OrganizationRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Organization IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var OrganizationResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof OrganizationRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', OrganizationRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Organization IRI is required for this operation');
+        }
+    }
+}

--- a/tests/Integration/Resource/Organization/CreateOrganizationTest.php
+++ b/tests/Integration/Resource/Organization/CreateOrganizationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Organization;
+
+use Apiera\Sdk\DTO\Request\Organization\OrganizationRequest;
+use Apiera\Sdk\DTO\Response\Organization\OrganizationResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestCreateOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class CreateOrganizationTest extends AbstractTestCreateOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/organizations';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Organization->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeCreateOperation(): OrganizationResponse
+    {
+        $request = new OrganizationRequest(
+            name: 'string',
+            extId: 'string',
+        );
+
+        return $this->sdk->organization()->create($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildUri('organizations', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'extId' => 'string',
+        ];
+    }
+
+    /**
+     * @return class-string<OrganizationResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return OrganizationResponse::class;
+    }
+
+    /**
+     * @param OrganizationResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals('string', $response->getExtId());
+    }
+}

--- a/tests/Integration/Resource/Organization/DeleteOrganizationTest.php
+++ b/tests/Integration/Resource/Organization/DeleteOrganizationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Organization;
+
+use Apiera\Sdk\DTO\Request\Organization\OrganizationRequest;
+use Apiera\Sdk\Enum\LdType;
+use Tests\Integration\Resource\AbstractTestDeleteOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class DeleteOrganizationTest extends AbstractTestDeleteOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/organizations';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Organization->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    protected function executeDeleteOperation(): void
+    {
+        $request = new OrganizationRequest(
+            iri: $this->buildUri('organizations', $this->resourceId)
+        );
+
+        $this->sdk->organization()->delete($request);
+    }
+}

--- a/tests/Integration/Resource/Organization/GetOrganizationTest.php
+++ b/tests/Integration/Resource/Organization/GetOrganizationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Organization;
+
+use Apiera\Sdk\DTO\Request\Organization\OrganizationRequest;
+use Apiera\Sdk\DTO\Response\Organization\OrganizationResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestGetOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class GetOrganizationTest extends AbstractTestGetOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/organizations';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Organization->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeGetOperation(): OrganizationResponse
+    {
+        $request = new OrganizationRequest(
+            iri: $this->buildUri('organizations', $this->resourceId)
+        );
+
+        return $this->sdk->organization()->get($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildUri('organizations', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'extId' => 'string',
+        ];
+    }
+
+    /**
+     * @return class-string<OrganizationResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return OrganizationResponse::class;
+    }
+
+    /**
+     * @param OrganizationResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals('string', $response->getExtId());
+    }
+}

--- a/tests/Integration/Resource/Organization/UpdateOrganizationTest.php
+++ b/tests/Integration/Resource/Organization/UpdateOrganizationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Organization;
+
+use Apiera\Sdk\DTO\Request\Organization\OrganizationRequest;
+use Apiera\Sdk\DTO\Response\Organization\OrganizationResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestUpdateOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class UpdateOrganizationTest extends AbstractTestUpdateOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/organizations';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Organization->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeUpdateOperation(): OrganizationResponse
+    {
+        $request = new OrganizationRequest(
+            name: 'string',
+            extId: 'string',
+            iri: $this->buildUri('organizations', $this->resourceId)
+        );
+
+        return $this->sdk->organization()->update($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildUri('organizations', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'extId' => 'string',
+        ];
+    }
+
+    /**
+     * @return class-string<OrganizationResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return OrganizationResponse::class;
+    }
+
+    /**
+     * @param OrganizationResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals('string', $response->getExtId());
+    }
+}

--- a/tests/Unit/DTO/Request/Organization/OrganizationRequestTest.php
+++ b/tests/Unit/DTO/Request/Organization/OrganizationRequestTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\Organization;
+
+use Apiera\Sdk\DTO\Request\Organization\OrganizationRequest;
+use Tests\Unit\DTO\Request\AbstractDTORequest;
+
+final class OrganizationRequestTest extends AbstractDTORequest
+{
+    protected function getRequestClass(): string
+    {
+        return OrganizationRequest::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getConstructorParams(): array
+    {
+        return [
+            'name' => 'Organization',
+            'extId' => 'string',
+            'alternateIdentifiers' => [
+                '/api/v1/alternate_identifiers/345',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/DTO/Request/Organization/OrganizationRequestTest.php
+++ b/tests/Unit/DTO/Request/Organization/OrganizationRequestTest.php
@@ -22,9 +22,6 @@ final class OrganizationRequestTest extends AbstractDTORequest
         return [
             'name' => 'Organization',
             'extId' => 'string',
-            'alternateIdentifiers' => [
-                '/api/v1/alternate_identifiers/345',
-            ],
         ];
     }
 }

--- a/tests/Unit/DTO/Response/Organization/OrganizationCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Organization/OrganizationCollectionResponseTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Organization;
+
+use Apiera\Sdk\DTO\Response\Organization\OrganizationCollectionResponse;
+use Apiera\Sdk\DTO\Response\Organization\OrganizationResponse;
+use Apiera\Sdk\DTO\Response\PartialCollectionView;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOCollectionResponse;
+
+final class OrganizationCollectionResponseTest extends AbstractDTOCollectionResponse
+{
+    protected function getCollectionClass(): string
+    {
+        return OrganizationCollectionResponse::class;
+    }
+
+    protected function getMemberClass(): string
+    {
+        return OrganizationResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getCollectionData(): array
+    {
+        $organizationResponse = new OrganizationResponse(
+            ldId: '/api/v1/stores/123/products/123',
+            ldType: LdType::Product,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Product',
+            extId: 'string',
+            alternateIdentifiers: [
+                '/api/v1/alternate_identifiers/345',
+            ],
+        );
+
+        return [
+            'ldContext' => '/api/v1/contexts/Product',
+            'ldId' => '/api/v1/stores/123/products',
+            'ldType' => LdType::Collection,
+            'ldMembers' => [$organizationResponse],
+            'ldTotalItems' => 1,
+            'ldView' => new PartialCollectionView(
+                ldId: '/api/v1/stores/123/products?page=1',
+                ldFirst: '/api/v1/stores/123/products?page=1',
+                ldLast: '/api/v1/stores/123/products?page=1',
+                ldNext: null,
+                ldPrevious: null
+            ),
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/Organization/OrganizationCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Organization/OrganizationCollectionResponseTest.php
@@ -30,25 +30,25 @@ final class OrganizationCollectionResponseTest extends AbstractDTOCollectionResp
     protected function getCollectionData(): array
     {
         $organizationResponse = new OrganizationResponse(
-            ldId: '/api/v1/stores/123/products/123',
-            ldType: LdType::Product,
+            ldId: '/api/v1/organizations/123',
+            ldType: LdType::Organization,
             uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
             updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
-            name: 'Product',
+            name: 'string',
             extId: 'string',
         );
 
         return [
-            'ldContext' => '/api/v1/contexts/Product',
-            'ldId' => '/api/v1/stores/123/products',
+            'ldContext' => '/api/v1/contexts/Organization',
+            'ldId' => '/api/v1/organizations',
             'ldType' => LdType::Collection,
             'ldMembers' => [$organizationResponse],
             'ldTotalItems' => 1,
             'ldView' => new PartialCollectionView(
-                ldId: '/api/v1/stores/123/products?page=1',
-                ldFirst: '/api/v1/stores/123/products?page=1',
-                ldLast: '/api/v1/stores/123/products?page=1',
+                ldId: '/api/v1/organizations?page=1',
+                ldFirst: '/api/v1/organizations?page=1',
+                ldLast: '/api/v1/organizations?page=1',
                 ldNext: null,
                 ldPrevious: null
             ),

--- a/tests/Unit/DTO/Response/Organization/OrganizationCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Organization/OrganizationCollectionResponseTest.php
@@ -37,9 +37,6 @@ final class OrganizationCollectionResponseTest extends AbstractDTOCollectionResp
             updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
             name: 'Product',
             extId: 'string',
-            alternateIdentifiers: [
-                '/api/v1/alternate_identifiers/345',
-            ],
         );
 
         return [

--- a/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
+++ b/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
@@ -43,9 +43,6 @@ final class OrganizationResponseTest extends AbstractDTOResponse
      */
     protected function getNullableFields(): array
     {
-        return [
-            'name' => null,
-            'extId' => null,
-        ];
+        return [];
     }
 }

--- a/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
+++ b/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
@@ -24,18 +24,18 @@ final class OrganizationResponseTest extends AbstractDTOResponse
     {
         return [
             'ldId' => '/api/v1/stores/123/products/123',
-            'ldType' => LdType::Product,
+            'ldType' =>  LdType::Organization,
             'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
-            'name' => 'Product',
+            'name' => 'string',
             'extId' => 'string',
         ];
     }
 
     protected function getExpectedLdType(): LdType
     {
-        return LdType::Product;
+        return LdType::Organization;
     }
 
     /**

--- a/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
+++ b/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
@@ -23,7 +23,7 @@ final class OrganizationResponseTest extends AbstractDTOResponse
     protected function getResponseData(): array
     {
         return [
-            'ldId' => '/api/v1/stores/123/products/123',
+            'ldId' => '/api/v1/organizations/123',
             'ldType' =>  LdType::Organization,
             'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),

--- a/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
+++ b/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Organization;
+
+use Apiera\Sdk\DTO\Response\Organization\OrganizationResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOResponse;
+
+final class OrganizationResponseTest extends AbstractDTOResponse
+{
+    protected function getResponseClass(): string
+    {
+        return OrganizationResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getResponseData(): array
+    {
+        return [
+            'ldId' => '/api/v1/stores/123/products/123',
+            'ldType' => LdType::Product,
+            'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'name' => 'Product',
+            'extId' => 'string',
+            'alternateIdentifiers' => [
+                '/api/v1/alternate_identifiers/345',
+            ],
+        ];
+    }
+
+    protected function getExpectedLdType(): LdType
+    {
+        return LdType::Product;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getNullableFields(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
+++ b/tests/Unit/DTO/Response/Organization/OrganizationResponseTest.php
@@ -30,9 +30,6 @@ final class OrganizationResponseTest extends AbstractDTOResponse
             'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'name' => 'Product',
             'extId' => 'string',
-            'alternateIdentifiers' => [
-                '/api/v1/alternate_identifiers/345',
-            ],
         ];
     }
 
@@ -46,6 +43,9 @@ final class OrganizationResponseTest extends AbstractDTOResponse
      */
     protected function getNullableFields(): array
     {
-        return [];
+        return [
+            'name' => null,
+            'extId' => null,
+        ];
     }
 }


### PR DESCRIPTION
### Description

This pull request introduces Data Transfer Objects (DTOs) and a resource for managing organizations, along with unit tests to validate their functionality.

**Changes Included:**
- Added `OrganizationResponse` and `OrganizationCollectionResponse` DTOs for representing organization data.
- Added `OrganizationRequest` DTO for handling input data.
- Implemented `OrganizationResource` for interfacing with the organizations API.
- Created unit tests for `OrganizationRequest`, `OrganizationResponse`, and `OrganizationCollectionResponse` DTOs to ensure proper structure, data handling, and behavior.