### PR TITLE
Add support for Tag entity with DTOs and tests

### DIFF
--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -15,6 +15,7 @@ use Apiera\Sdk\Resource\FileResource;
 use Apiera\Sdk\Resource\InventoryLocationResource;
 use Apiera\Sdk\Resource\ProductResource;
 use Apiera\Sdk\Resource\PropertyResource;
+use Apiera\Sdk\Resource\TagResource;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
@@ -101,5 +102,12 @@ final readonly class ApieraSdk
         $dataMapper = new ReflectionAttributeDataMapper();
 
         return new InventoryLocationResource($this->client, $dataMapper);
+    }
+
+    public function tag(): TagResource
+    {
+        $dataMapper = new ReflectionAttributeDataMapper();
+
+        return new TagResource($this->client, $dataMapper);
     }
 }

--- a/src/DTO/Request/Tag/TagRequest.php
+++ b/src/DTO/Request/Tag/TagRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\Tag;
+
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\SkipRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class TagRequest implements RequestInterface
+{
+    public function __construct(
+        #[RequestField('name')]
+        private string $name,
+        #[RequestField('store')]
+        private string $store,
+        #[SkipRequest]
+        private ?string $iri = null
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getStore(): string
+    {
+        return $this->store;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'store' => $this->store,
+        ];
+    }
+}

--- a/src/DTO/Request/Tag/TagRequest.php
+++ b/src/DTO/Request/Tag/TagRequest.php
@@ -16,20 +16,20 @@ final readonly class TagRequest implements RequestInterface
 {
     public function __construct(
         #[RequestField('name')]
-        private string $name,
+        private ?string $name = null,
         #[RequestField('store')]
-        private string $store,
+        private ?string $store = null,
         #[SkipRequest]
         private ?string $iri = null
     ) {
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getStore(): string
+    public function getStore(): ?string
     {
         return $this->store;
     }

--- a/src/DTO/Request/Tag/TagRequest.php
+++ b/src/DTO/Request/Tag/TagRequest.php
@@ -46,7 +46,6 @@ final readonly class TagRequest implements RequestInterface
     {
         return [
             'name' => $this->name,
-            'store' => $this->store,
         ];
     }
 }

--- a/src/DTO/Response/Tag/TagCollectionResponse.php
+++ b/src/DTO/Response/Tag/TagCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Tag;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class TagCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<TagResponse>
+     */
+    public function getLdMembers(): array
+    {
+        /** @var array<TagResponse> $members */
+        $members = parent::getLdMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/Tag/TagResponse.php
+++ b/src/DTO/Response/Tag/TagResponse.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Tag;
+
+use Apiera\Sdk\Attribute\JsonLdResponseField;
+use Apiera\Sdk\Attribute\ResponseField;
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Transformer\DateTimeTransformer;
+use Apiera\Sdk\Transformer\LdTypeTransformer;
+use Apiera\Sdk\Transformer\UuidTransformer;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class TagResponse extends AbstractResponse
+{
+    public function __construct(
+        #[JsonLdResponseField('@id')]
+        private string $ldId,
+        #[JsonLdResponseField('@type', LdTypeTransformer::class)]
+        private LdType $ldType,
+        #[ResponseField('uuid', UuidTransformer::class)]
+        private Uuid $uuid,
+        #[ResponseField('createdAt', DateTimeTransformer::class)]
+        private DateTimeInterface $createdAt,
+        #[ResponseField('updatedAt', DateTimeTransformer::class)]
+        private DateTimeInterface $updatedAt,
+        #[ResponseField('name')]
+        private string $name,
+        #[ResponseField('store')]
+        private string $store,
+    ) {
+        parent::__construct(
+            $this->ldId,
+            $this->ldType,
+            $this->uuid,
+            $this->createdAt,
+            $this->updatedAt
+        );
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getStore(): string
+    {
+        return $this->store;
+    }
+}

--- a/src/DTO/Response/Tag/TagResponse.php
+++ b/src/DTO/Response/Tag/TagResponse.php
@@ -32,9 +32,9 @@ final readonly class TagResponse extends AbstractResponse
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
         #[ResponseField('name')]
-        private string $name,
+        private ?string $name = null,
         #[ResponseField('store')]
-        private string $store,
+        private ?string $store = null,
     ) {
         parent::__construct(
             $this->ldId,
@@ -45,12 +45,12 @@ final readonly class TagResponse extends AbstractResponse
         );
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getStore(): string
+    public function getStore(): ?string
     {
         return $this->store;
     }

--- a/src/DTO/Response/Tag/TagResponse.php
+++ b/src/DTO/Response/Tag/TagResponse.php
@@ -32,9 +32,9 @@ final readonly class TagResponse extends AbstractResponse
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
         #[ResponseField('name')]
-        private ?string $name = null,
+        private string $name,
         #[ResponseField('store')]
-        private ?string $store = null,
+        private string $store,
     ) {
         parent::__construct(
             $this->ldId,
@@ -45,12 +45,12 @@ final readonly class TagResponse extends AbstractResponse
         );
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getStore(): ?string
+    public function getStore(): string
     {
         return $this->store;
     }

--- a/src/Enum/LdType.php
+++ b/src/Enum/LdType.php
@@ -24,6 +24,8 @@ use Apiera\Sdk\DTO\Response\Product\ProductCollectionResponse;
 use Apiera\Sdk\DTO\Response\Product\ProductResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\DTO\Response\Tag\TagCollectionResponse;
+use Apiera\Sdk\DTO\Response\Tag\TagResponse;
 use Exception;
 use InvalidArgumentException;
 
@@ -100,6 +102,10 @@ enum LdType: string
                 ResponseType::Single->value => InventoryLocationResponse::class,
                 ResponseType::Collection->value => InventoryLocationCollectionResponse::class,
             ],
+            self::Tag => [
+                ResponseType::Single->value => TagResponse::class,
+                ResponseType::Collection->value => TagCollectionResponse::class,
+            ],
             self::Integration,
             self::IntegrationResourceMap,
             self::Inventory,
@@ -107,7 +113,6 @@ enum LdType: string
             self::PropertyTerm,
             self::Sku,
             self::Store,
-            self::Tag,
             self::Variant => throw new Exception('To be implemented'),
             self::Collection => throw new InvalidArgumentException(
                 'Collection type cannot be mapped directly'

--- a/src/Resource/TagResource.php
+++ b/src/Resource/TagResource.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\Tag\TagRequest;
+use Apiera\Sdk\DTO\Response\Tag\TagCollectionResponse;
+use Apiera\Sdk\DTO\Response\Tag\TagResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnoge.no>
+ * @since 0.3.0
+ */
+final readonly class TagResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/tags';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function find(RequestInterface $request, ?QueryParameters $params = null): TagCollectionResponse
+    {
+        if (!$request instanceof TagRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', TagRequest::class)
+            );
+        }
+
+        if (!$request->getStore()) {
+            throw new InvalidRequestException('Store IRI is required for this operation');
+        }
+
+        /** @var TagCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): TagResponse
+    {
+        if (!$request instanceof TagRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', TagRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getLdTotalItems() < 1) {
+            throw new InvalidRequestException('No tag found matching the given criteria');
+        }
+
+        return $collection->getLdMembers()[0];
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function get(RequestInterface $request): TagResponse
+    {
+        if (!$request instanceof TagRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', TagRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Tag IRI is required for this operation');
+        }
+
+        /** @var TagResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function create(RequestInterface $request): TagResponse
+    {
+        if (!$request instanceof TagRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', TagRequest::class)
+            );
+        }
+
+        if (!$request->getStore()) {
+            throw new InvalidRequestException('Store IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var TagResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function update(RequestInterface $request): TagResponse
+    {
+        if (!$request instanceof TagRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', TagRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Tag IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var TagResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof TagRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', TagRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Tag IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/tests/Integration/Resource/Tag/CreateTagTest.php
+++ b/tests/Integration/Resource/Tag/CreateTagTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Tag;
+
+use Apiera\Sdk\DTO\Request\Tag\TagRequest;
+use Apiera\Sdk\DTO\Response\Tag\TagResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestCreateOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class CreateTagTest extends AbstractTestCreateOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return '/tags';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Tag->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeCreateOperation(): TagResponse
+    {
+        $request = new TagRequest(
+            name: 'string',
+            store: $this->buildStoreUri()
+        );
+
+        return $this->sdk->tag()->create($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildStoreUri('tags', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'store' => $this->buildStoreUri(),
+        ];
+    }
+
+    /**
+     * @return class-string<TagResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return TagResponse::class;
+    }
+
+    /**
+     * @param TagResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals($this->buildStoreUri(), $response->getStore());
+    }
+}

--- a/tests/Integration/Resource/Tag/DeleteTagTest.php
+++ b/tests/Integration/Resource/Tag/DeleteTagTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Tag;
+
+use Apiera\Sdk\DTO\Request\Tag\TagRequest;
+use Apiera\Sdk\Enum\LdType;
+use Tests\Integration\Resource\AbstractTestDeleteOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class DeleteTagTest extends AbstractTestDeleteOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return '/tags';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Attribute->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    protected function executeDeleteOperation(): void
+    {
+        $request = new TagRequest(
+            iri: $this->buildStoreUri('tags', $this->resourceId)
+        );
+
+        $this->sdk->tag()->delete($request);
+    }
+}

--- a/tests/Integration/Resource/Tag/GetTagTest.php
+++ b/tests/Integration/Resource/Tag/GetTagTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Tag;
+
+use Apiera\Sdk\DTO\Request\Tag\TagRequest;
+use Apiera\Sdk\DTO\Response\Tag\TagResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestGetOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class GetTagTest extends AbstractTestGetOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return '/tags';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Tag->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeGetOperation(): TagResponse
+    {
+        $request = new TagRequest(
+            iri: $this->buildStoreUri('tags', $this->resourceId),
+        );
+
+        return $this->sdk->tag()->get($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildStoreUri('tags', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'store' => $this->buildStoreUri(),
+        ];
+    }
+
+    /**
+     * @return class-string<TagResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return TagResponse::class;
+    }
+
+    /**
+     * @param TagResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals($this->buildStoreUri(), $response->getStore());
+    }
+}

--- a/tests/Integration/Resource/Tag/UpdateTagTest.php
+++ b/tests/Integration/Resource/Tag/UpdateTagTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Tag;
+
+use Apiera\Sdk\DTO\Request\Tag\TagRequest;
+use Apiera\Sdk\DTO\Response\Tag\TagResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestUpdateOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class UpdateTagTest extends AbstractTestUpdateOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return '/tags';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Tag->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeUpdateOperation(): TagResponse
+    {
+        $request = new TagRequest(
+            name: 'string',
+            iri: $this->buildStoreUri('tags', $this->resourceId),
+        );
+
+        return $this->sdk->tag()->update($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildStoreUri('tags', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'store' => $this->buildStoreUri(),
+        ];
+    }
+
+    /**
+     * @return class-string<TagResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return TagResponse::class;
+    }
+
+    /**
+     * @param TagResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals($this->buildStoreUri(), $response->getStore());
+    }
+}

--- a/tests/Unit/DTO/Request/Tag/TagRequestTest.php
+++ b/tests/Unit/DTO/Request/Tag/TagRequestTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\Tag;
+
+use Apiera\Sdk\DTO\Request\Tag\TagRequest;
+use Tests\Unit\DTO\Request\AbstractDTORequest;
+
+final class TagRequestTest extends AbstractDTORequest
+{
+    protected function getRequestClass(): string
+    {
+        return TagRequest::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getConstructorParams(): array
+    {
+        return [
+            'name' => 'Tag',
+            'store' => '/api/v1/stores/123',
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/Tag/TagCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Tag/TagCollectionResponseTest.php
@@ -30,7 +30,7 @@ final class TagCollectionResponseTest extends AbstractDTOCollectionResponse
     protected function getCollectionData(): array
     {
         $tagResponse = new TagResponse(
-            ldId: '/api/v1/tags/123/tags/123',
+            ldId: '/api/v1/stores/123/tags/123',
             ldType: LdType::Tag,
             uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
@@ -46,9 +46,9 @@ final class TagCollectionResponseTest extends AbstractDTOCollectionResponse
             'ldMembers' => [$tagResponse],
             'ldTotalItems' => 1,
             'ldView' => new PartialCollectionView(
-                ldId: '/api/v1/stores/123/products?page=1',
-                ldFirst: '/api/v1/stores/123/products?page=1',
-                ldLast: '/api/v1/stores/123/products?page=1',
+                ldId: '/api/v1/stores/123/tags?page=1',
+                ldFirst: '/api/v1/stores/123/tags?page=1',
+                ldLast: '/api/v1/stores/123/tags?page=1',
                 ldNext: null,
                 ldPrevious: null
             ),

--- a/tests/Unit/DTO/Response/Tag/TagCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Tag/TagCollectionResponseTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Tag;
+
+use Apiera\Sdk\DTO\Response\PartialCollectionView;
+use Apiera\Sdk\DTO\Response\Tag\TagCollectionResponse;
+use Apiera\Sdk\DTO\Response\Tag\TagResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOCollectionResponse;
+
+final class TagCollectionResponseTest extends AbstractDTOCollectionResponse
+{
+    protected function getCollectionClass(): string
+    {
+        return TagCollectionResponse::class;
+    }
+
+    protected function getMemberClass(): string
+    {
+        return TagResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getCollectionData(): array
+    {
+        $tagResponse = new TagResponse(
+            ldId: '/api/v1/tags/123/tags/123',
+            ldType: LdType::Tag,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Tag',
+            store: '/api/v1/stores/123',
+        );
+
+        return [
+            'ldContext' => '/api/v1/contexts/Tag',
+            'ldId' => '/api/v1/stores/123/tags',
+            'ldType' => LdType::Collection,
+            'ldMembers' => [$tagResponse],
+            'ldTotalItems' => 1,
+            'ldView' => new PartialCollectionView(
+                ldId: '/api/v1/stores/123/products?page=1',
+                ldFirst: '/api/v1/stores/123/products?page=1',
+                ldLast: '/api/v1/stores/123/products?page=1',
+                ldNext: null,
+                ldPrevious: null
+            ),
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/Tag/TagResponseTest.php
+++ b/tests/Unit/DTO/Response/Tag/TagResponseTest.php
@@ -23,14 +23,14 @@ final class TagResponseTest extends AbstractDTOResponse
     protected function getResponseData(): array
     {
         return [
-            'ldId' => '/api/v1/tags/123/tags/123',
+            'ldId' => '/api/v1/stores/123/tags/123',
             'ldType' => LdType::Tag,
             'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'name' => 'Tag',
             'store' => '/api/v1/stores/123',
-            ];
+        ];
     }
 
     /**
@@ -38,10 +38,7 @@ final class TagResponseTest extends AbstractDTOResponse
      */
     protected function getNullableFields(): array
     {
-        return [
-            'name' => null,
-            'store' => null,
-        ];
+        return [];
     }
 
     protected function getExpectedLdType(): LdType

--- a/tests/Unit/DTO/Response/Tag/TagResponseTest.php
+++ b/tests/Unit/DTO/Response/Tag/TagResponseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Tag;
+
+use Apiera\Sdk\DTO\Response\Tag\TagResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOResponse;
+
+final class TagResponseTest extends AbstractDTOResponse
+{
+    protected function getResponseClass(): string
+    {
+        return TagResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getResponseData(): array
+    {
+        return [
+            'ldId' => '/api/v1/tags/123/tags/123',
+            'ldType' => LdType::Tag,
+            'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'name' => 'Tag',
+            'store' => '/api/v1/stores/123',
+            ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getNullableFields(): array
+    {
+        return [];
+    }
+
+    protected function getExpectedLdType(): LdType
+    {
+        return LdType::Tag;
+    }
+}

--- a/tests/Unit/DTO/Response/Tag/TagResponseTest.php
+++ b/tests/Unit/DTO/Response/Tag/TagResponseTest.php
@@ -38,7 +38,10 @@ final class TagResponseTest extends AbstractDTOResponse
      */
     protected function getNullableFields(): array
     {
-        return [];
+        return [
+            'name' => null,
+            'store' => null,
+        ];
     }
 
     protected function getExpectedLdType(): LdType


### PR DESCRIPTION
### Description

This pull request introduces support for the `Tag` entity in the SDK, including the addition of DTO classes and resources to manage Tag-related operations: creation, retrieval, updating, and deletion. The following components are introduced:

- `TagRequest`: DTO for creating and updating tags.
- `TagResponse`: DTO for retrieving individual tag details.
- `TagCollectionResponse`: DTO for handling collections of tags.
- `TagResource`: Resource class for managing API interactions for tags.

Additionally, unit tests have been added for `TagRequest`, `TagResponse`, and `TagCollectionResponse` to validate their structure, data handling, and expected behaviors. These enhancements ensure reliable functionality for tag operations.