### PR TITLE
Add StoreResource with CRUD operations and improve test coverage

### DIFF
--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -15,6 +15,7 @@ use Apiera\Sdk\Resource\FileResource;
 use Apiera\Sdk\Resource\InventoryLocationResource;
 use Apiera\Sdk\Resource\ProductResource;
 use Apiera\Sdk\Resource\PropertyResource;
+use Apiera\Sdk\Resource\StoreResource;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
@@ -101,5 +102,12 @@ final readonly class ApieraSdk
         $dataMapper = new ReflectionAttributeDataMapper();
 
         return new InventoryLocationResource($this->client, $dataMapper);
+    }
+
+    public function store(): StoreResource
+    {
+        $dataMapper = new ReflectionAttributeDataMapper();
+
+        return new StoreResource($this->client, $dataMapper);
     }
 }

--- a/src/DTO/Request/Store/StoreRequest.php
+++ b/src/DTO/Request/Store/StoreRequest.php
@@ -16,34 +16,24 @@ final readonly class StoreRequest implements RequestInterface
 {
     /**
      * @param string[] $properties
-     * @param string[] $propertyTerms
      */
     public function __construct(
         #[RequestField('name')]
-        private string $name,
-        #[RequestField('organization')]
-        private string $organization,
+        private ?string $name = null,
         #[RequestField('description')]
         private ?string $description = null,
         #[RequestField('image')]
         private ?string $image = null,
         #[RequestField('properties')]
         private array $properties = [],
-        #[RequestField('propertyTerms')]
-        private array $propertyTerms = [],
         #[SkipRequest]
         private ?string $iri = null,
     ) {
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
-    }
-
-    public function getOrganization(): string
-    {
-        return $this->organization;
     }
 
     public function getDescription(): ?string
@@ -64,14 +54,6 @@ final readonly class StoreRequest implements RequestInterface
         return $this->properties;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getPropertyTerms(): array
-    {
-        return $this->propertyTerms;
-    }
-
     public function getIri(): ?string
     {
         return $this->iri;
@@ -84,11 +66,9 @@ final readonly class StoreRequest implements RequestInterface
     {
         return [
             'name' => $this->name,
-            'organization' => $this->organization,
             'description' => $this->description,
             'image' => $this->image,
             'properties' => $this->properties,
-            'propertyTerms' => $this->propertyTerms,
         ];
     }
 }

--- a/src/DTO/Request/Store/StoreRequest.php
+++ b/src/DTO/Request/Store/StoreRequest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\Store;
+
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\SkipRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class StoreRequest implements RequestInterface
+{
+    /**
+     * @param string[] $properties
+     * @param string[] $propertyTerms
+     */
+    public function __construct(
+        #[RequestField('name')]
+        private string $name,
+        #[RequestField('organization')]
+        private string $organization,
+        #[RequestField('description')]
+        private ?string $description = null,
+        #[RequestField('image')]
+        private ?string $image = null,
+        #[RequestField('properties')]
+        private array $properties = [],
+        #[RequestField('propertyTerms')]
+        private array $propertyTerms = [],
+        #[SkipRequest]
+        private ?string $iri = null,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getOrganization(): string
+    {
+        return $this->organization;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getImage(): ?string
+    {
+        return $this->image;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPropertyTerms(): array
+    {
+        return $this->propertyTerms;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'organization' => $this->organization,
+            'description' => $this->description,
+            'image' => $this->image,
+            'properties' => $this->properties,
+            'propertyTerms' => $this->propertyTerms,
+        ];
+    }
+}

--- a/src/DTO/Request/Store/StoreRequest.php
+++ b/src/DTO/Request/Store/StoreRequest.php
@@ -14,9 +14,6 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
  */
 final readonly class StoreRequest implements RequestInterface
 {
-    /**
-     * @param string[] $properties
-     */
     public function __construct(
         #[RequestField('name')]
         private ?string $name = null,
@@ -24,8 +21,6 @@ final readonly class StoreRequest implements RequestInterface
         private ?string $description = null,
         #[RequestField('image')]
         private ?string $image = null,
-        #[RequestField('properties')]
-        private array $properties = [],
         #[SkipRequest]
         private ?string $iri = null,
     ) {
@@ -46,14 +41,6 @@ final readonly class StoreRequest implements RequestInterface
         return $this->image;
     }
 
-    /**
-     * @return string[]
-     */
-    public function getProperties(): array
-    {
-        return $this->properties;
-    }
-
     public function getIri(): ?string
     {
         return $this->iri;
@@ -68,7 +55,6 @@ final readonly class StoreRequest implements RequestInterface
             'name' => $this->name,
             'description' => $this->description,
             'image' => $this->image,
-            'properties' => $this->properties,
         ];
     }
 }

--- a/src/DTO/Response/Store/StoreCollectionResponse.php
+++ b/src/DTO/Response/Store/StoreCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Store;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class StoreCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<StoreResponse>
+     */
+    public function getLdMembers(): array
+    {
+        /** @var array<StoreResponse> $members */
+        $members = parent::getLdMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/Store/StoreResponse.php
+++ b/src/DTO/Response/Store/StoreResponse.php
@@ -38,8 +38,6 @@ final readonly class StoreResponse extends AbstractResponse
         private DateTimeInterface $updatedAt,
         #[RequestField('name')]
         private string $name,
-        #[RequestField('organization')]
-        private string $organization,
         #[RequestField('description')]
         private ?string $description = null,
         #[RequestField('image')]
@@ -61,11 +59,6 @@ final readonly class StoreResponse extends AbstractResponse
     public function getName(): string
     {
         return $this->name;
-    }
-
-    public function getOrganization(): string
-    {
-        return $this->organization;
     }
 
     public function getDescription(): ?string

--- a/src/DTO/Response/Store/StoreResponse.php
+++ b/src/DTO/Response/Store/StoreResponse.php
@@ -21,10 +21,6 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class StoreResponse extends AbstractResponse
 {
-    /**
-     * @param string[] $properties
-     * @param string[] $propertyTerms
-     */
     public function __construct(
         #[JsonLdResponseField('@id')]
         private string $ldId,
@@ -37,15 +33,11 @@ final readonly class StoreResponse extends AbstractResponse
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
         #[RequestField('name')]
-        private string $name,
+        private ?string $name = null,
         #[RequestField('description')]
         private ?string $description = null,
         #[RequestField('image')]
         private ?string $image = null,
-        #[RequestField('properties')]
-        private array $properties = [],
-        #[RequestField('propertyTerms')]
-        private array $propertyTerms = [],
     ) {
         parent::__construct(
             $this->ldId,
@@ -56,7 +48,7 @@ final readonly class StoreResponse extends AbstractResponse
         );
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -69,21 +61,5 @@ final readonly class StoreResponse extends AbstractResponse
     public function getImage(): ?string
     {
         return $this->image;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getProperties(): array
-    {
-        return $this->properties;
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getPropertyTerms(): array
-    {
-        return $this->propertyTerms;
     }
 }

--- a/src/DTO/Response/Store/StoreResponse.php
+++ b/src/DTO/Response/Store/StoreResponse.php
@@ -33,7 +33,7 @@ final readonly class StoreResponse extends AbstractResponse
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
         #[RequestField('name')]
-        private ?string $name = null,
+        private ?string $name,
         #[RequestField('description')]
         private ?string $description = null,
         #[RequestField('image')]
@@ -48,7 +48,7 @@ final readonly class StoreResponse extends AbstractResponse
         );
     }
 
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/DTO/Response/Store/StoreResponse.php
+++ b/src/DTO/Response/Store/StoreResponse.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Apiera\Sdk\DTO\Response\Store;
 
 use Apiera\Sdk\Attribute\JsonLdResponseField;
-use Apiera\Sdk\Attribute\RequestField;
 use Apiera\Sdk\Attribute\ResponseField;
 use Apiera\Sdk\DTO\Response\AbstractResponse;
 use Apiera\Sdk\Enum\LdType;
@@ -32,11 +31,11 @@ final readonly class StoreResponse extends AbstractResponse
         private DateTimeInterface $createdAt,
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
-        #[RequestField('name')]
-        private ?string $name,
-        #[RequestField('description')]
+        #[ResponseField('name')]
+        private string $name,
+        #[ResponseField('description')]
         private ?string $description = null,
-        #[RequestField('image')]
+        #[ResponseField('image')]
         private ?string $image = null,
     ) {
         parent::__construct(

--- a/src/DTO/Response/Store/StoreResponse.php
+++ b/src/DTO/Response/Store/StoreResponse.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Store;
+
+use Apiera\Sdk\Attribute\JsonLdResponseField;
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\ResponseField;
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Transformer\DateTimeTransformer;
+use Apiera\Sdk\Transformer\LdTypeTransformer;
+use Apiera\Sdk\Transformer\UuidTransformer;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class StoreResponse extends AbstractResponse
+{
+    /**
+     * @param string[] $properties
+     * @param string[] $propertyTerms
+     */
+    public function __construct(
+        #[JsonLdResponseField('@id')]
+        private string $ldId,
+        #[JsonLdResponseField('@type', LdTypeTransformer::class)]
+        private LdType $ldType,
+        #[ResponseField('uuid', UuidTransformer::class)]
+        private Uuid $uuid,
+        #[ResponseField('createdAt', DateTimeTransformer::class)]
+        private DateTimeInterface $createdAt,
+        #[ResponseField('updatedAt', DateTimeTransformer::class)]
+        private DateTimeInterface $updatedAt,
+        #[RequestField('name')]
+        private string $name,
+        #[RequestField('organization')]
+        private string $organization,
+        #[RequestField('description')]
+        private ?string $description = null,
+        #[RequestField('image')]
+        private ?string $image = null,
+        #[RequestField('properties')]
+        private array $properties = [],
+        #[RequestField('propertyTerms')]
+        private array $propertyTerms = [],
+    ) {
+        parent::__construct(
+            $this->ldId,
+            $this->ldType,
+            $this->uuid,
+            $this->createdAt,
+            $this->updatedAt
+        );
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getOrganization(): string
+    {
+        return $this->organization;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getImage(): ?string
+    {
+        return $this->image;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getPropertyTerms(): array
+    {
+        return $this->propertyTerms;
+    }
+}

--- a/src/Enum/LdType.php
+++ b/src/Enum/LdType.php
@@ -24,6 +24,8 @@ use Apiera\Sdk\DTO\Response\Product\ProductCollectionResponse;
 use Apiera\Sdk\DTO\Response\Product\ProductResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\DTO\Response\Store\StoreCollectionResponse;
+use Apiera\Sdk\DTO\Response\Store\StoreResponse;
 use Exception;
 use InvalidArgumentException;
 
@@ -100,13 +102,16 @@ enum LdType: string
                 ResponseType::Single->value => InventoryLocationResponse::class,
                 ResponseType::Collection->value => InventoryLocationCollectionResponse::class,
             ],
+            self::Store => [
+                ResponseType::Single->value => StoreResponse::class,
+                ResponseType::Collection->value => StoreCollectionResponse::class,
+            ],
             self::Integration,
             self::IntegrationResourceMap,
             self::Inventory,
             self::Organization,
             self::PropertyTerm,
             self::Sku,
-            self::Store,
             self::Tag,
             self::Variant => throw new Exception('To be implemented'),
             self::Collection => throw new InvalidArgumentException(

--- a/src/Resource/StoreResource.php
+++ b/src/Resource/StoreResource.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\Store\StoreRequest;
+use Apiera\Sdk\DTO\Response\Store\StoreCollectionResponse;
+use Apiera\Sdk\DTO\Response\Store\StoreResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class StoreResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/stores';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function find(RequestInterface $request, ?QueryParameters $params = null): StoreCollectionResponse
+    {
+        if (!$request instanceof StoreRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', Storerequest::class)
+            );
+        }
+
+        /** @var StoreCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get(self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): StoreResponse
+    {
+        if (!$request instanceof StoreRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', StoreRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getLdTotalItems() < 1) {
+            throw new InvalidRequestException('No store found matching the given criteria');
+        }
+
+        return $collection->getLdMembers()[0];
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function get(RequestInterface $request): StoreResponse
+    {
+        if (!$request instanceof StoreRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', StoreRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Store IRI is required for this operation');
+        }
+
+        /** @var StoreResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function create(RequestInterface $request): StoreResponse
+    {
+        if (!$request instanceof StoreRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', StoreRequest::class)
+            );
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var StoreResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post(self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function update(RequestInterface $request): StoreResponse
+    {
+        if (!$request instanceof StoreRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', StoreRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Store IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var StoreResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof StoreRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', StoreRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Store IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/src/Resource/StoreResource.php
+++ b/src/Resource/StoreResource.php
@@ -20,7 +20,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
  */
 final readonly class StoreResource implements RequestResourceInterface
 {
-    private const string ENDPOINT = '/stores';
+    private const string ENDPOINT = '/api/v1/stores';
 
     public function __construct(
         private ClientInterface $client,

--- a/tests/Integration/Resource/Store/CreateStoreTest.php
+++ b/tests/Integration/Resource/Store/CreateStoreTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Store;
+
+use Apiera\Sdk\DTO\Request\Store\StoreRequest;
+use Apiera\Sdk\DTO\Response\Store\StoreResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestCreateOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class CreateStoreTest extends AbstractTestCreateOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/stores';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Store->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeCreateOperation(): StoreResponse
+    {
+        $request = new StoreRequest(
+            name: 'string',
+            description: 'string',
+            image: '/api/v1/files/123',
+        );
+
+        return $this->sdk->store()->create($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildUri('stores', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'description' => 'string',
+            'image' => '/api/v1/files/123',
+        ];
+    }
+
+    /**
+     * @return class-string<StoreResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return StoreResponse::class;
+    }
+
+    /**
+     * @param StoreResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals('string', $response->getDescription());
+        $this->assertEquals('/api/v1/files/123', $response->getImage());
+    }
+}

--- a/tests/Integration/Resource/Store/DeleteStoreTest.php
+++ b/tests/Integration/Resource/Store/DeleteStoreTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Store;
+
+use Apiera\Sdk\DTO\Request\Store\StoreRequest;
+use Apiera\Sdk\Enum\LdType;
+use Tests\Integration\Resource\AbstractTestDeleteOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class DeleteStoreTest extends AbstractTestDeleteOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/stores';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::AlternateIdentifier->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    protected function executeDeleteOperation(): void
+    {
+        $request = new StoreRequest(
+            iri: $this->buildUri('stores', $this->resourceId)
+        );
+
+        $this->sdk->store()->delete($request);
+    }
+}

--- a/tests/Integration/Resource/Store/GetStoreTest.php
+++ b/tests/Integration/Resource/Store/GetStoreTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Store;
+
+use Apiera\Sdk\DTO\Request\Store\StoreRequest;
+use Apiera\Sdk\DTO\Response\Store\StoreResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestGetOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class GetStoreTest extends AbstractTestGetOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/stores';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Store->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeGetOperation(): StoreResponse
+    {
+        $request = new StoreRequest(
+            iri: $this->buildUri('stores', $this->resourceId)
+        );
+
+        return $this->sdk->store()->get($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildUri('stores', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'description' => 'string',
+            'image' => '/api/v1/files/123',
+        ];
+    }
+
+    /**
+     * @return class-string<StoreResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return StoreResponse::class;
+    }
+
+    /**
+     * @param StoreResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals('string', $response->getDescription());
+        $this->assertEquals('/api/v1/files/123', $response->getImage());
+    }
+}

--- a/tests/Integration/Resource/Store/UpdateStoreTest.php
+++ b/tests/Integration/Resource/Store/UpdateStoreTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Store;
+
+use Apiera\Sdk\DTO\Request\Store\StoreRequest;
+use Apiera\Sdk\DTO\Response\Store\StoreResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestUpdateOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class UpdateStoreTest extends AbstractTestUpdateOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/stores';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Store->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeUpdateOperation(): StoreResponse
+    {
+        $request = new StoreRequest(
+            name: 'string',
+            description: 'string',
+            image: '/api/v1/files/123',
+            iri: $this->buildUri('stores', $this->resourceId)
+        );
+
+        return $this->sdk->store()->update($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildUri('stores', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'description' => 'string',
+            'image' => '/api/v1/files/123',
+        ];
+    }
+
+    /**
+     * @return class-string<StoreResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return StoreResponse::class;
+    }
+
+    /**
+     * @param StoreResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals('string', $response->getDescription());
+        $this->assertEquals('/api/v1/files/123', $response->getImage());
+    }
+}

--- a/tests/Unit/DTO/Request/Store/StoreRequestTest.php
+++ b/tests/Unit/DTO/Request/Store/StoreRequestTest.php
@@ -23,9 +23,6 @@ final class StoreRequestTest extends AbstractDTORequest
             'name' => 'Store',
             'description' => 'Description',
             'image' => '/api/v1/files/123',
-            'properties' => [
-                '/api/v1/stores/123/properties/456',
-            ],
         ];
     }
 }

--- a/tests/Unit/DTO/Request/Store/StoreRequestTest.php
+++ b/tests/Unit/DTO/Request/Store/StoreRequestTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\Store;
+
+use Apiera\Sdk\DTO\Request\Store\StoreRequest;
+use Tests\Unit\DTO\Request\AbstractDTORequest;
+
+final class StoreRequestTest extends AbstractDTORequest
+{
+    protected function getRequestClass(): string
+    {
+        return StoreRequest::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getConstructorParams(): array
+    {
+        return [
+            'name' => 'Store',
+            'description' => 'Description',
+            'organization' => 'string',
+            'image' => '/api/v1/files/123',
+            'properties' => [
+                '/api/v1/stores/123/properties/456',
+            ],
+            'propertyTerms' => [
+                '/api/v1/stores/123/properties/456/terms/789',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/DTO/Request/Store/StoreRequestTest.php
+++ b/tests/Unit/DTO/Request/Store/StoreRequestTest.php
@@ -22,13 +22,9 @@ final class StoreRequestTest extends AbstractDTORequest
         return [
             'name' => 'Store',
             'description' => 'Description',
-            'organization' => 'string',
             'image' => '/api/v1/files/123',
             'properties' => [
                 '/api/v1/stores/123/properties/456',
-            ],
-            'propertyTerms' => [
-                '/api/v1/stores/123/properties/456/terms/789',
             ],
         ];
     }

--- a/tests/Unit/DTO/Response/Store/StoreCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Store/StoreCollectionResponseTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Store;
+
+use Apiera\Sdk\DTO\Response\PartialCollectionView;
+use Apiera\Sdk\DTO\Response\Store\StoreCollectionResponse;
+use Apiera\Sdk\DTO\Response\Store\StoreResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOCollectionResponse;
+
+final class StoreCollectionResponseTest extends AbstractDTOCollectionResponse
+{
+    protected function getCollectionClass(): string
+    {
+        return StoreCollectionResponse::class;
+    }
+
+    protected function getMemberClass(): string
+    {
+        return StoreResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getCollectionData(): array
+    {
+        $storeResponse = new StoreResponse(
+            ldId: '/api/v1/stores/123/store/123',
+            ldType: LdType::Store,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'Store',
+            description: 'Description',
+            image: '/api/v1/files/123',
+            properties: [
+                '/api/v1/stores/123/properties/456',
+            ],
+            propertyTerms: [
+                '/api/v1/stores/123/properties/456/terms/789',
+            ],
+        );
+
+        return [
+            'ldContext' => '/api/v1/contexts/Store',
+            'ldId' => '/api/v1/stores/123/stores',
+            'ldType' => LdType::Collection,
+            'ldMembers' => [$storeResponse],
+            'ldTotalItems' => 1,
+            'ldView' => new PartialCollectionView(
+                ldId: '/api/v1/stores/123/products?page=1',
+                ldFirst: '/api/v1/stores/123/products?page=1',
+                ldLast: '/api/v1/stores/123/products?page=1',
+                ldNext: null,
+                ldPrevious: null
+            ),
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/Store/StoreCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Store/StoreCollectionResponseTest.php
@@ -38,12 +38,6 @@ final class StoreCollectionResponseTest extends AbstractDTOCollectionResponse
             name: 'Store',
             description: 'Description',
             image: '/api/v1/files/123',
-            properties: [
-                '/api/v1/stores/123/properties/456',
-            ],
-            propertyTerms: [
-                '/api/v1/stores/123/properties/456/terms/789',
-            ],
         );
 
         return [

--- a/tests/Unit/DTO/Response/Store/StoreResponseTest.php
+++ b/tests/Unit/DTO/Response/Store/StoreResponseTest.php
@@ -31,12 +31,6 @@ final class StoreResponseTest extends AbstractDTOResponse
             'name' => 'Store',
             'description' => 'Description',
             'image' => '/api/v1/files/123',
-            'properties' => [
-                '/api/v1/stores/123/properties/456',
-            ],
-            'propertyTerms' => [
-                '/api/v1/stores/123/properties/456/terms/789',
-            ],
         ];
     }
 
@@ -46,6 +40,7 @@ final class StoreResponseTest extends AbstractDTOResponse
     protected function getNullableFields(): array
     {
         return [
+            'name' => null,
             'description' => null,
             'image' => null,
         ];

--- a/tests/Unit/DTO/Response/Store/StoreResponseTest.php
+++ b/tests/Unit/DTO/Response/Store/StoreResponseTest.php
@@ -23,8 +23,8 @@ final class StoreResponseTest extends AbstractDTOResponse
     protected function getResponseData(): array
     {
         return [
-            'ldId' => '/api/v1/stores/123/products/123',
-            'ldType' => LdType::Product,
+            'ldId' => '/api/v1/stores/123',
+            'ldType' => LdType::Store,
             'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
@@ -40,7 +40,6 @@ final class StoreResponseTest extends AbstractDTOResponse
     protected function getNullableFields(): array
     {
         return [
-            'name' => null,
             'description' => null,
             'image' => null,
         ];
@@ -48,6 +47,6 @@ final class StoreResponseTest extends AbstractDTOResponse
 
     protected function getExpectedLdType(): LdType
     {
-        return LdType::Product;
+        return LdType::Store;
     }
 }

--- a/tests/Unit/DTO/Response/Store/StoreResponseTest.php
+++ b/tests/Unit/DTO/Response/Store/StoreResponseTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Store;
+
+use Apiera\Sdk\DTO\Response\Store\StoreResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOResponse;
+
+final class StoreResponseTest extends AbstractDTOResponse
+{
+    protected function getResponseClass(): string
+    {
+        return StoreResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getResponseData(): array
+    {
+        return [
+            'ldId' => '/api/v1/stores/123/products/123',
+            'ldType' => LdType::Product,
+            'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'name' => 'Store',
+            'description' => 'Description',
+            'image' => '/api/v1/files/123',
+            'properties' => [
+                '/api/v1/stores/123/properties/456',
+            ],
+            'propertyTerms' => [
+                '/api/v1/stores/123/properties/456/terms/789',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getNullableFields(): array
+    {
+        return [
+            'description' => null,
+            'image' => null,
+        ];
+    }
+
+    protected function getExpectedLdType(): LdType
+    {
+        return LdType::Product;
+    }
+}


### PR DESCRIPTION
### Description of changes

- Introduced `StoreResource`, enabling CRUD operations for stores with robust validation, mapping, and error handling.
- Added unit tests for `StoreResponse`, `StoreCollectionResponse`, and `StoreRequest` to enhance test coverage.
- Removed the unused `organization` field from `StoreResponse` for better alignment with current requirements. 