### PR TITLE
Add Sku resource with array support and CRUD methods

### DIFF
--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -15,6 +15,7 @@ use Apiera\Sdk\Resource\FileResource;
 use Apiera\Sdk\Resource\InventoryLocationResource;
 use Apiera\Sdk\Resource\ProductResource;
 use Apiera\Sdk\Resource\PropertyResource;
+use Apiera\Sdk\Resource\SkuResource;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
@@ -101,5 +102,12 @@ final readonly class ApieraSdk
         $dataMapper = new ReflectionAttributeDataMapper();
 
         return new InventoryLocationResource($this->client, $dataMapper);
+    }
+
+    public function sku(): SkuResource
+    {
+        $dataMapper = new ReflectionAttributeDataMapper();
+
+        return new SkuResource($this->client, $dataMapper);
     }
 }

--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -111,7 +111,7 @@ final readonly class ApieraSdk
 
         return new OrganizationResource($this->client, $dataMapper);
     }
-  
+
     public function sku(): SkuResource
     {
         $dataMapper = new ReflectionAttributeDataMapper();

--- a/src/DTO/Request/Sku/SkuRequest.php
+++ b/src/DTO/Request/Sku/SkuRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\Sku;
+
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\SkipRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class SkuRequest implements RequestInterface
+{
+    public function __construct(
+        #[RequestField('code')]
+        private string $code,
+        #[RequestField('organization')]
+        private string $organization,
+        #[SkipRequest]
+        private ?string $iri = null
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getOrganization(): string
+    {
+        return $this->organization;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'code' => $this->code,
+            'organization' => $this->organization,
+        ];
+    }
+}

--- a/src/DTO/Request/Sku/SkuRequest.php
+++ b/src/DTO/Request/Sku/SkuRequest.php
@@ -16,22 +16,15 @@ final readonly class SkuRequest implements RequestInterface
 {
     public function __construct(
         #[RequestField('code')]
-        private string $code,
-        #[RequestField('organization')]
-        private string $organization,
+        private ?string $code = null,
         #[SkipRequest]
         private ?string $iri = null
     ) {
     }
 
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->code;
-    }
-
-    public function getOrganization(): string
-    {
-        return $this->organization;
     }
 
     public function getIri(): ?string
@@ -46,7 +39,6 @@ final readonly class SkuRequest implements RequestInterface
     {
         return [
             'code' => $this->code,
-            'organization' => $this->organization,
         ];
     }
 }

--- a/src/DTO/Response/Sku/SkuCollectionResponse.php
+++ b/src/DTO/Response/Sku/SkuCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Sku;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class SkuCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<SkuResponse>
+     */
+    public function getLdMembers(): array
+    {
+        /** @var array<SkuResponse> $members */
+        $members = parent::getLdMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/Sku/SkuResponse.php
+++ b/src/DTO/Response/Sku/SkuResponse.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Apiera\Sdk\DTO\Response\Sku;
 
 use Apiera\Sdk\Attribute\JsonLdResponseField;
-use Apiera\Sdk\Attribute\RequestField;
 use Apiera\Sdk\Attribute\ResponseField;
 use Apiera\Sdk\DTO\Response\AbstractResponse;
 use Apiera\Sdk\Enum\LdType;
@@ -37,13 +36,13 @@ final readonly class SkuResponse extends AbstractResponse
         private DateTimeInterface $createdAt,
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
-        #[RequestField('code')]
-        private ?string $code = null,
-        #[RequestField('products')]
+        #[ResponseField('code')]
+        private string $code,
+        #[ResponseField('products')]
         private array $products = [],
-        #[RequestField('variants')]
+        #[ResponseField('variants')]
         private array $variants = [],
-        #[RequestField('inventories')]
+        #[ResponseField('inventories')]
         private array $inventories = [],
     ) {
         parent::__construct(
@@ -55,7 +54,7 @@ final readonly class SkuResponse extends AbstractResponse
         );
     }
 
-    public function getCode(): ?string
+    public function getCode(): string
     {
         return $this->code;
     }

--- a/src/DTO/Response/Sku/SkuResponse.php
+++ b/src/DTO/Response/Sku/SkuResponse.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Sku;
+
+use Apiera\Sdk\Attribute\JsonLdResponseField;
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\ResponseField;
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Transformer\DateTimeTransformer;
+use Apiera\Sdk\Transformer\LdTypeTransformer;
+use Apiera\Sdk\Transformer\UuidTransformer;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class SkuResponse extends AbstractResponse
+{
+    public function __construct(
+        #[JsonLdResponseField('@id')]
+        private string $ldId,
+        #[JsonLdResponseField('@type', LdTypeTransformer::class)]
+        private LdType $ldType,
+        #[ResponseField('uuid', UuidTransformer::class)]
+        private Uuid $uuid,
+        #[ResponseField('createdAt', DateTimeTransformer::class)]
+        private DateTimeInterface $createdAt,
+        #[ResponseField('updatedAt', DateTimeTransformer::class)]
+        private DateTimeInterface $updatedAt,
+        #[RequestField('code')]
+        private string $code,
+        #[RequestField('variants')]
+        private string $variants,
+        #[RequestField('inventories')]
+        private string $inventories,
+    ) {
+        parent::__construct(
+            $this->ldId,
+            $this->ldType,
+            $this->uuid,
+            $this->createdAt,
+            $this->updatedAt
+        );
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function getVariants(): string
+    {
+        return $this->variants;
+    }
+
+    public function getInventories(): string
+    {
+        return $this->inventories;
+    }
+}

--- a/src/DTO/Response/Sku/SkuResponse.php
+++ b/src/DTO/Response/Sku/SkuResponse.php
@@ -21,6 +21,11 @@ use Symfony\Component\Uid\Uuid;
  */
 final readonly class SkuResponse extends AbstractResponse
 {
+    /**
+     * @param string[] $products
+     * @param string[] $variants
+     * @param string[] $inventories
+     */
     public function __construct(
         #[JsonLdResponseField('@id')]
         private string $ldId,
@@ -34,10 +39,12 @@ final readonly class SkuResponse extends AbstractResponse
         private DateTimeInterface $updatedAt,
         #[RequestField('code')]
         private string $code,
+        #[RequestField('products')]
+        private array $products = [],
         #[RequestField('variants')]
-        private string $variants,
+        private array $variants = [],
         #[RequestField('inventories')]
-        private string $inventories,
+        private array $inventories = [],
     ) {
         parent::__construct(
             $this->ldId,
@@ -53,12 +60,26 @@ final readonly class SkuResponse extends AbstractResponse
         return $this->code;
     }
 
-    public function getVariants(): string
+    /**
+     * @return string[]
+     */
+    public function getProducts(): array
+    {
+        return $this->products;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getVariants(): array
     {
         return $this->variants;
     }
 
-    public function getInventories(): string
+    /**
+     * @return string[]
+     */
+    public function getInventories(): array
     {
         return $this->inventories;
     }

--- a/src/DTO/Response/Sku/SkuResponse.php
+++ b/src/DTO/Response/Sku/SkuResponse.php
@@ -38,7 +38,7 @@ final readonly class SkuResponse extends AbstractResponse
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
         #[RequestField('code')]
-        private string $code,
+        private ?string $code = null,
         #[RequestField('products')]
         private array $products = [],
         #[RequestField('variants')]
@@ -55,7 +55,7 @@ final readonly class SkuResponse extends AbstractResponse
         );
     }
 
-    public function getCode(): string
+    public function getCode(): ?string
     {
         return $this->code;
     }

--- a/src/Enum/LdType.php
+++ b/src/Enum/LdType.php
@@ -24,6 +24,8 @@ use Apiera\Sdk\DTO\Response\Product\ProductCollectionResponse;
 use Apiera\Sdk\DTO\Response\Product\ProductResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\DTO\Response\Sku\SkuCollectionResponse;
+use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
 use Exception;
 use InvalidArgumentException;
 
@@ -100,12 +102,15 @@ enum LdType: string
                 ResponseType::Single->value => InventoryLocationResponse::class,
                 ResponseType::Collection->value => InventoryLocationCollectionResponse::class,
             ],
+            self::Sku => [
+                ResponseType::Single->value => SkuResponse::class,
+                ResponseType::Collection->value => SkuCollectionResponse::class,
+            ],
             self::Integration,
             self::IntegrationResourceMap,
             self::Inventory,
             self::Organization,
             self::PropertyTerm,
-            self::Sku,
             self::Store,
             self::Tag,
             self::Variant => throw new Exception('To be implemented'),

--- a/src/Resource/SkuResource.php
+++ b/src/Resource/SkuResource.php
@@ -20,7 +20,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
  */
 final readonly class SkuResource implements RequestResourceInterface
 {
-    private const string ENDPOINT = '/skus';
+    private const string ENDPOINT = '/api/v1/skus';
 
     public function __construct(
         private ClientInterface $client,

--- a/src/Resource/SkuResource.php
+++ b/src/Resource/SkuResource.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\Sku\SkuRequest;
+use Apiera\Sdk\DTO\Response\Sku\SkuCollectionResponse;
+use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class SkuResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/skus';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function find(RequestInterface $request, ?QueryParameters $params = null): SkuCollectionResponse
+    {
+        if (!$request instanceof SkuRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', SkuRequest::class)
+            );
+        }
+
+        /** @var SkuCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get(self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): SkuResponse
+    {
+        if (!$request instanceof SkuRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', SkuRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getLdTotalItems() < 1) {
+            throw new InvalidRequestException('No sku found matching the given criteria');
+        }
+
+        return $collection->getLdMembers()[0];
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function get(RequestInterface $request): SkuResponse
+    {
+        if (!$request instanceof SkuRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', SkuRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Sku IRI is required for this operation');
+        }
+
+        /** @var SkuResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function create(RequestInterface $request): SkuResponse
+    {
+        if (!$request instanceof SkuRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', SkuRequest::class)
+            );
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var SkuResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post(self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function update(RequestInterface $request): SkuResponse
+    {
+        if (!$request instanceof SkuRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', SkuRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Sku IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var SkuResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof SkuRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', SkuRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Sku IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/tests/Integration/Resource/Sku/CreateSkuTest.php
+++ b/tests/Integration/Resource/Sku/CreateSkuTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Sku;
+
+use Apiera\Sdk\DTO\Request\Sku\SkuRequest;
+use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestCreateOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class CreateSkuTest extends AbstractTestCreateOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/skus';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Sku->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeCreateOperation(): SkuResponse
+    {
+        $request = new SkuRequest(
+            code: 'string'
+        );
+
+        return $this->sdk->sku()->create($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildUri('skus', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'code' => 'string',
+            'products' => [],
+            'variants' => [],
+            'inventories' => [],
+        ];
+    }
+
+    /**
+     * @return class-string<SkuResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return SkuResponse::class;
+    }
+
+    /**
+     * @param SkuResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getCode());
+        $this->assertIsArray($response->getProducts());
+        $this->assertIsArray($response->getVariants());
+        $this->assertIsArray($response->getInventories());
+    }
+}

--- a/tests/Integration/Resource/Sku/DeleteSkuTest.php
+++ b/tests/Integration/Resource/Sku/DeleteSkuTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Sku;
+
+use Apiera\Sdk\DTO\Request\Sku\SkuRequest;
+use Apiera\Sdk\Enum\LdType;
+use Tests\Integration\Resource\AbstractTestDeleteOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class DeleteSkuTest extends AbstractTestDeleteOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/skus';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Sku->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    protected function executeDeleteOperation(): void
+    {
+        $request = new SkuRequest(
+            iri: $this->buildUri('skus', $this->resourceId)
+        );
+
+        $this->sdk->sku()->delete($request);
+    }
+}

--- a/tests/Integration/Resource/Sku/GetSkuTest.php
+++ b/tests/Integration/Resource/Sku/GetSkuTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Sku;
+
+use Apiera\Sdk\DTO\Request\Sku\SkuRequest;
+use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestGetOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class GetSkuTest extends AbstractTestGetOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/skus';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Sku->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeGetOperation(): SkuResponse
+    {
+        $request = new SkuRequest(
+            iri: $this->buildUri('skus', $this->resourceId)
+        );
+
+        return $this->sdk->sku()->get($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildUri('skus', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'code' => 'string',
+            'products' => [],
+            'variants' => [],
+            'inventories' => [],
+        ];
+    }
+
+    /**
+     * @return class-string<SkuResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return SkuResponse::class;
+    }
+
+    /**
+     * @param SkuResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getCode());
+        $this->assertIsArray($response->getProducts());
+        $this->assertIsArray($response->getVariants());
+        $this->assertIsArray($response->getInventories());
+    }
+}

--- a/tests/Integration/Resource/Sku/UpdateSkuTest.php
+++ b/tests/Integration/Resource/Sku/UpdateSkuTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Sku;
+
+use Apiera\Sdk\DTO\Request\Sku\SkuRequest;
+use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestUpdateOperation;
+use Tests\Integration\Resource\ResourceOperationTrait;
+
+final class UpdateSkuTest extends AbstractTestUpdateOperation
+{
+    use ResourceOperationTrait;
+
+    protected function getResourcePath(): string
+    {
+        return '/skus';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Sku->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeUpdateOperation(): SkuResponse
+    {
+        $request = new SkuRequest(
+            code: 'string',
+            iri: $this->buildUri('skus', $this->resourceId)
+        );
+
+        return $this->sdk->sku()->update($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildUri('skus', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'code' => 'string',
+            'products' => [],
+            'variants' => [],
+            'inventories' => [],
+        ];
+    }
+
+    /**
+     * @return class-string<SkuResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return SkuResponse::class;
+    }
+
+    /**
+     * @param SkuResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getCode());
+        $this->assertIsArray($response->getProducts());
+        $this->assertIsArray($response->getVariants());
+        $this->assertIsArray($response->getInventories());
+    }
+}

--- a/tests/Unit/DTO/Request/Sku/SkuRequestTest.php
+++ b/tests/Unit/DTO/Request/Sku/SkuRequestTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\Sku;
+
+use Apiera\Sdk\DTO\Request\Sku\SkuRequest;
+use Tests\Unit\DTO\Request\AbstractDTORequest;
+
+final class SkuRequestTest extends AbstractDTORequest
+{
+    protected function getRequestClass(): string
+    {
+        return SkuRequest::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getConstructorParams(): array
+    {
+        return [
+            'code' => 'string',
+            'organization' => 'Product',
+        ];
+    }
+}

--- a/tests/Unit/DTO/Request/Sku/SkuRequestTest.php
+++ b/tests/Unit/DTO/Request/Sku/SkuRequestTest.php
@@ -21,7 +21,6 @@ final class SkuRequestTest extends AbstractDTORequest
     {
         return [
             'code' => 'string',
-            'organization' => 'Product',
         ];
     }
 }

--- a/tests/Unit/DTO/Response/Sku/SkuCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Sku/SkuCollectionResponseTest.php
@@ -30,33 +30,33 @@ final class SkuCollectionResponseTest extends AbstractDTOCollectionResponse
     protected function getCollectionData(): array
     {
         $skuResponse = new SkuResponse(
-            ldId: '/api/v1/stores/123/products/123',
-            ldType:LdType::Product,
+            ldId: '/api/v1/skus/123',
+            ldType:LdType::Sku,
             uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
             updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
             code: 'string',
             products: [
-                'products',
+                '/api/v1/stores/123/products/123',
             ],
             variants: [
-                'variants',
+                '/api/v1/stores/123/products/123/variants/123',
             ],
             inventories: [
-                'inventories',
+                '/api/v1/inventory_locations/123/inventories/123',
             ],
         );
 
         return [
             'ldContext' => '/api/v1/contexts/Sku',
-            'ldId' => '/api/v1/stores/123/skus',
+            'ldId' => '/api/v1/skus',
             'ldType' => LdType::Collection,
             'ldMembers' => [$skuResponse],
             'ldTotalItems' => 1,
             'ldView' => new PartialCollectionView(
-                ldId: '/api/v1/stores/123/sku?page=1',
-                ldFirst: '/api/v1/stores/123/sku?page=1',
-                ldLast: '/api/v1/stores/123/sku?page=1',
+                ldId: '/api/v1/skus?page=1',
+                ldFirst: '/api/v1/skus?page=1',
+                ldLast: '/api/v1/skus?page=1',
                 ldNext: null,
                 ldPrevious: null
             ),

--- a/tests/Unit/DTO/Response/Sku/SkuCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Sku/SkuCollectionResponseTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Sku;
+
+use Apiera\Sdk\DTO\Response\PartialCollectionView;
+use Apiera\Sdk\DTO\Response\Sku\SkuCollectionResponse;
+use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOCollectionResponse;
+
+final class SkuCollectionResponseTest extends AbstractDTOCollectionResponse
+{
+    protected function getCollectionClass(): string
+    {
+        return SkuCollectionResponse::class;
+    }
+
+    protected function getMemberClass(): string
+    {
+        return SkuResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getCollectionData(): array
+    {
+        $skuResponse = new SkuResponse(
+            ldId: '/api/v1/stores/123/products/123',
+            ldType:LdType::Product,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            code: 'string',
+            products: [
+                'products',
+            ],
+            variants: [
+                'variants',
+            ],
+            inventories: [
+                'inventories',
+            ],
+        );
+
+        return [
+            'ldContext' => '/api/v1/contexts/Sku',
+            'ldId' => '/api/v1/stores/123/skus',
+            'ldType' => LdType::Collection,
+            'ldMembers' => [$skuResponse],
+            'ldTotalItems' => 1,
+            'ldView' => new PartialCollectionView(
+                ldId: '/api/v1/stores/123/sku?page=1',
+                ldFirst: '/api/v1/stores/123/sku?page=1',
+                ldLast: '/api/v1/stores/123/sku?page=1',
+                ldNext: null,
+                ldPrevious: null
+            ),
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/Sku/SkuResponseTest.php
+++ b/tests/Unit/DTO/Response/Sku/SkuResponseTest.php
@@ -23,27 +23,27 @@ final class SkuResponseTest extends AbstractDTOResponse
     protected function getResponseData(): array
     {
         return [
-            'ldId' => '/api/v1/stores/123/products/123',
-            'ldType' => LdType::Product,
+            'ldId' => '/api/v1/skus/123',
+            'ldType' => LdType::Sku,
             'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'code' => 'string',
             'products' => [
-                'products',
+                '/api/v1/stores/123/products/123',
             ],
             'variants' => [
-                'variants',
+                '/api/v1/stores/123/products/123/variants/123',
             ],
             'inventories' => [
-                'inventories',
+                '/api/v1/inventory_locations/123/inventories/123',
             ],
         ];
     }
 
     protected function getExpectedLdType(): LdType
     {
-        return LdType::Product;
+        return LdType::Sku;
     }
 
     /**
@@ -51,8 +51,6 @@ final class SkuResponseTest extends AbstractDTOResponse
      */
     protected function getNullableFields(): array
     {
-        return [
-            'code' => null,
-        ];
+        return [];
     }
 }

--- a/tests/Unit/DTO/Response/Sku/SkuResponseTest.php
+++ b/tests/Unit/DTO/Response/Sku/SkuResponseTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Sku;
+
+use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOResponse;
+
+final class SkuResponseTest extends AbstractDTOResponse
+{
+    protected function getResponseClass(): string
+    {
+        return SkuResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getResponseData(): array
+    {
+        return [
+            'ldId' => '/api/v1/stores/123/products/123',
+            'ldType' => LdType::Product,
+            'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'code' => 'string',
+            'products' => [
+                'products',
+            ],
+            'variants' => [
+                'variants',
+            ],
+            'inventories' => [
+                'inventories',
+            ],
+        ];
+    }
+
+    protected function getExpectedLdType(): LdType
+    {
+        return LdType::Product;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getNullableFields(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/DTO/Response/Sku/SkuResponseTest.php
+++ b/tests/Unit/DTO/Response/Sku/SkuResponseTest.php
@@ -51,6 +51,8 @@ final class SkuResponseTest extends AbstractDTOResponse
      */
     protected function getNullableFields(): array
     {
-        return [];
+        return [
+            'code' => null,
+        ];
     }
 }


### PR DESCRIPTION
### Description

This pull request introduces the `SkuResource` with complete support for SKU-related operations. Key updates include:

1. **CRUD Operations**:
   - Added methods to perform Create, Read, Update, and Delete operations for SKUs.
   - Implemented validation and data mapping for seamless integration.

2. **Array Field Support in `SkuResponse`**:
   - Updated `products`, `variants`, and `inventories` fields in `SkuResponse` to support arrays.
   - Enhanced data handling for multi-entry SKU attributes.

3. **Request/Response DTOs**:
   - Introduced `SkuRequest`, `SkuResponse`, and `SkuCollectionResponse` for efficient data handling and API communication.

4. **Unit Testing**:
   - Added comprehensive unit tests for `SkuResponse`, `SkuRequest`, and `SkuCollectionResponse` to ensure functionality and reliability. 
