### PR TITLE
Add PropertyTerm DTOs and their unit tests

### DIFF
--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -15,6 +15,7 @@ use Apiera\Sdk\Resource\FileResource;
 use Apiera\Sdk\Resource\InventoryLocationResource;
 use Apiera\Sdk\Resource\ProductResource;
 use Apiera\Sdk\Resource\PropertyResource;
+use Apiera\Sdk\Resource\PropertyTermResource;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
@@ -101,5 +102,12 @@ final readonly class ApieraSdk
         $dataMapper = new ReflectionAttributeDataMapper();
 
         return new InventoryLocationResource($this->client, $dataMapper);
+    }
+
+    public function propertyTerm(): PropertyTermResource
+    {
+        $dataMapper = new ReflectionAttributeDataMapper();
+
+        return new PropertyTermResource($this->client, $dataMapper);
     }
 }

--- a/src/DTO/Request/PropertyTerm/PropertyTermRequest.php
+++ b/src/DTO/Request/PropertyTerm/PropertyTermRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\PropertyTerm;
+
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\SkipRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class PropertyTermRequest implements RequestInterface
+{
+    public function __construct(
+        #[RequestField('name')]
+        private string $name,
+        #[RequestField('property')]
+        private string $property,
+        #[RequestField('store')]
+        private string $store,
+        #[SkipRequest]
+        private ?string $iri = null
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    public function getStore(): string
+    {
+        return $this->store;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'property' => $this->property,
+            'store' => $this->store,
+        ];
+    }
+}

--- a/src/DTO/Request/PropertyTerm/PropertyTermRequest.php
+++ b/src/DTO/Request/PropertyTerm/PropertyTermRequest.php
@@ -19,8 +19,6 @@ final readonly class PropertyTermRequest implements RequestInterface
         private string $name,
         #[RequestField('property')]
         private string $property,
-        #[RequestField('store')]
-        private string $store,
         #[SkipRequest]
         private ?string $iri = null
     ) {
@@ -36,11 +34,6 @@ final readonly class PropertyTermRequest implements RequestInterface
         return $this->property;
     }
 
-    public function getStore(): string
-    {
-        return $this->store;
-    }
-
     public function getIri(): ?string
     {
         return $this->iri;
@@ -54,7 +47,6 @@ final readonly class PropertyTermRequest implements RequestInterface
         return [
             'name' => $this->name,
             'property' => $this->property,
-            'store' => $this->store,
         ];
     }
 }

--- a/src/DTO/Request/PropertyTerm/PropertyTermRequest.php
+++ b/src/DTO/Request/PropertyTerm/PropertyTermRequest.php
@@ -16,20 +16,20 @@ final readonly class PropertyTermRequest implements RequestInterface
 {
     public function __construct(
         #[RequestField('name')]
-        private string $name,
+        private ?string $name = null,
         #[RequestField('property')]
-        private string $property,
+        private ?string $property = null,
         #[SkipRequest]
         private ?string $iri = null
     ) {
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getProperty(): string
+    public function getProperty(): ?string
     {
         return $this->property;
     }
@@ -45,7 +45,6 @@ final readonly class PropertyTermRequest implements RequestInterface
     public function toArray(): array
     {
         return [
-            'name' => $this->name,
             'property' => $this->property,
         ];
     }

--- a/src/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
+++ b/src/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\PropertyTerm;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class PropertyTermCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<PropertyTermResponse>
+     */
+    public function getLdMembers(): array
+    {
+        /** @var array<PropertyTermResponse> $members */
+        $members = parent::getLdMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/PropertyTerm/PropertyTermResponse.php
+++ b/src/DTO/Response/PropertyTerm/PropertyTermResponse.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Apiera\Sdk\DTO\Response\PropertyTerm;
 
 use Apiera\Sdk\Attribute\JsonLdResponseField;
-use Apiera\Sdk\Attribute\RequestField;
 use Apiera\Sdk\Attribute\ResponseField;
 use Apiera\Sdk\DTO\Response\AbstractResponse;
 use Apiera\Sdk\Enum\LdType;
@@ -32,10 +31,12 @@ final readonly class PropertyTermResponse extends AbstractResponse
         private DateTimeInterface $createdAt,
         #[ResponseField('updatedAt', DateTimeTransformer::class)]
         private DateTimeInterface $updatedAt,
-        #[RequestField('name')]
+        #[ResponseField('name')]
         private string $name,
-        #[RequestField('property')]
+        #[ResponseField('property')]
         private string $property,
+        #[ResponseField('store')]
+        private string $store,
     ) {
         parent::__construct(
             $this->ldId,
@@ -54,5 +55,10 @@ final readonly class PropertyTermResponse extends AbstractResponse
     public function getProperty(): string
     {
         return $this->property;
+    }
+
+    public function getStore(): string
+    {
+        return $this->store;
     }
 }

--- a/src/DTO/Response/PropertyTerm/PropertyTermResponse.php
+++ b/src/DTO/Response/PropertyTerm/PropertyTermResponse.php
@@ -36,8 +36,6 @@ final readonly class PropertyTermResponse extends AbstractResponse
         private string $name,
         #[RequestField('property')]
         private string $property,
-        #[RequestField('store')]
-        private string $store,
     ) {
         parent::__construct(
             $this->ldId,
@@ -56,10 +54,5 @@ final readonly class PropertyTermResponse extends AbstractResponse
     public function getProperty(): string
     {
         return $this->property;
-    }
-
-    public function getStore(): string
-    {
-        return $this->store;
     }
 }

--- a/src/DTO/Response/PropertyTerm/PropertyTermResponse.php
+++ b/src/DTO/Response/PropertyTerm/PropertyTermResponse.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\PropertyTerm;
+
+use Apiera\Sdk\Attribute\JsonLdResponseField;
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\ResponseField;
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Transformer\DateTimeTransformer;
+use Apiera\Sdk\Transformer\LdTypeTransformer;
+use Apiera\Sdk\Transformer\UuidTransformer;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class PropertyTermResponse extends AbstractResponse
+{
+    public function __construct(
+        #[JsonLdResponseField('@id')]
+        private string $ldId,
+        #[JsonLdResponseField('@type', LdTypeTransformer::class)]
+        private LdType $ldType,
+        #[ResponseField('uuid', UuidTransformer::class)]
+        private Uuid $uuid,
+        #[ResponseField('createdAt', DateTimeTransformer::class)]
+        private DateTimeInterface $createdAt,
+        #[ResponseField('updatedAt', DateTimeTransformer::class)]
+        private DateTimeInterface $updatedAt,
+        #[RequestField('name')]
+        private string $name,
+        #[RequestField('property')]
+        private string $property,
+        #[RequestField('store')]
+        private string $store,
+    ) {
+        parent::__construct(
+            $this->ldId,
+            $this->ldType,
+            $this->uuid,
+            $this->createdAt,
+            $this->updatedAt
+        );
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    public function getStore(): string
+    {
+        return $this->store;
+    }
+}

--- a/src/Enum/LdType.php
+++ b/src/Enum/LdType.php
@@ -24,6 +24,8 @@ use Apiera\Sdk\DTO\Response\Product\ProductCollectionResponse;
 use Apiera\Sdk\DTO\Response\Product\ProductResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
+use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermCollectionResponse;
+use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
 use Exception;
 use InvalidArgumentException;
 
@@ -100,11 +102,14 @@ enum LdType: string
                 ResponseType::Single->value => InventoryLocationResponse::class,
                 ResponseType::Collection->value => InventoryLocationCollectionResponse::class,
             ],
+            self::PropertyTerm => [
+                ResponseType::Single->value => PropertyTermResponse::class,
+                ResponseType::Collection->value => PropertyTermCollectionResponse::class,
+            ],
             self::Integration,
             self::IntegrationResourceMap,
             self::Inventory,
             self::Organization,
-            self::PropertyTerm,
             self::Sku,
             self::Store,
             self::Tag,

--- a/src/Resource/PropertyTermResource.php
+++ b/src/Resource/PropertyTermResource.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\PropertyTerm\PropertyTermRequest;
+use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermCollectionResponse;
+use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class PropertyTermResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/propertyTerms';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function find(RequestInterface $request, ?QueryParameters $params = null): PropertyTermCollectionResponse
+    {
+        if (!$request instanceof PropertyTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyTermRequest::class)
+            );
+        }
+
+        if (!$request->getStore()) {
+            throw new InvalidRequestException('Store IRI is required for this operation');
+        }
+
+        /** @var PropertyTermCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): PropertyTermResponse
+    {
+        if (!$request instanceof PropertyTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyTermRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getLdTotalItems() < 1) {
+            throw new InvalidRequestException('No property term found matching the given criteria');
+        }
+
+        return $collection->getLdMembers()[0];
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function get(RequestInterface $request): PropertyTermResponse
+    {
+        if (!$request instanceof PropertyTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyTermRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Property term IRI is required for this operation');
+        }
+
+        /** @var PropertyTermResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function create(RequestInterface $request): PropertyTermResponse
+    {
+        if (!$request instanceof PropertyTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyTermRequest::class)
+            );
+        }
+
+        if (!$request->getStore()) {
+            throw new InvalidRequestException('Store IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var PropertyTermResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function update(RequestInterface $request): PropertyTermResponse
+    {
+        if (!$request instanceof PropertyTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyTermRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Property term IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var PropertyTermResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof PropertyTermRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', PropertyTermRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Property term IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/src/Resource/PropertyTermResource.php
+++ b/src/Resource/PropertyTermResource.php
@@ -42,7 +42,7 @@ final readonly class PropertyTermResource implements RequestResourceInterface
         }
 
         if (!$request->getProperty()) {
-            throw new InvalidRequestException('Store IRI is required for this operation');
+            throw new InvalidRequestException('Property IRI is required for this operation');
         }
 
         /** @var PropertyTermCollectionResponse $collectionResponse */
@@ -114,7 +114,7 @@ final readonly class PropertyTermResource implements RequestResourceInterface
         }
 
         if (!$request->getProperty()) {
-            throw new InvalidRequestException('Store IRI is required for this operation');
+            throw new InvalidRequestException('Property IRI is required for this operation');
         }
 
         $requestData = $this->mapper->toRequestData($request);

--- a/src/Resource/PropertyTermResource.php
+++ b/src/Resource/PropertyTermResource.php
@@ -20,7 +20,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
  */
 final readonly class PropertyTermResource implements RequestResourceInterface
 {
-    private const string ENDPOINT = '/propertyTerms';
+    private const string ENDPOINT = '/terms';
 
     public function __construct(
         private ClientInterface $client,
@@ -41,13 +41,13 @@ final readonly class PropertyTermResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        if (!$request->getProperty()) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var PropertyTermCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($request->getProperty() . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -113,7 +113,7 @@ final readonly class PropertyTermResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        if (!$request->getProperty()) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -121,7 +121,7 @@ final readonly class PropertyTermResource implements RequestResourceInterface
 
         /** @var PropertyTermResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($request->getProperty() . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/tests/Integration/Resource/PropertyTerm/CreatePropertyTermTest.php
+++ b/tests/Integration/Resource/PropertyTerm/CreatePropertyTermTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\PropertyTerm;
+
+use Apiera\Sdk\DTO\Request\PropertyTerm\PropertyTermRequest;
+use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestCreateOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class CreatePropertyTermTest extends AbstractTestCreateOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return sprintf('/properties/%s/terms', $this->resourceId);
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::PropertyTerm->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeCreateOperation(): PropertyTermResponse
+    {
+        $request = new PropertyTermRequest(
+            name: 'string',
+            property: $this->buildStoreUri('properties', $this->resourceId),
+        );
+
+        return $this->sdk->propertyTerm()->create($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildStoreUri('properties', $this->resourceId, 'terms', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'property' => $this->buildStoreUri('properties', $this->resourceId),
+            'store' => $this->buildStoreUri(),
+        ];
+    }
+
+    /**
+     * @return class-string<PropertyTermResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return PropertyTermResponse::class;
+    }
+
+    /**
+     * @param PropertyTermResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals($this->buildStoreUri('properties', $this->resourceId), $response->getProperty());
+        $this->assertEquals($this->buildStoreUri(), $response->getStore());
+    }
+}

--- a/tests/Integration/Resource/PropertyTerm/DeletePropertyTermTest.php
+++ b/tests/Integration/Resource/PropertyTerm/DeletePropertyTermTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\PropertyTerm;
+
+use Apiera\Sdk\DTO\Request\PropertyTerm\PropertyTermRequest;
+use Apiera\Sdk\Enum\LdType;
+use Tests\Integration\Resource\AbstractTestDeleteOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class DeletePropertyTermTest extends AbstractTestDeleteOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return sprintf('/properties/%s/terms', $this->resourceId);
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::PropertyTerm->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    protected function executeDeleteOperation(): void
+    {
+        $request = new PropertyTermRequest(
+            iri: $this->buildStoreUri('properties', $this->resourceId, 'terms', $this->resourceId),
+        );
+
+        $this->sdk->propertyTerm()->delete($request);
+    }
+}

--- a/tests/Integration/Resource/PropertyTerm/GetPropertyTermTest.php
+++ b/tests/Integration/Resource/PropertyTerm/GetPropertyTermTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\PropertyTerm;
+
+use Apiera\Sdk\DTO\Request\PropertyTerm\PropertyTermRequest;
+use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestGetOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class GetPropertyTermTest extends AbstractTestGetOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return sprintf('/properties/%s/terms', $this->resourceId);
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::PropertyTerm->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeGetOperation(): PropertyTermResponse
+    {
+        $request = new PropertyTermRequest(
+            iri: $this->buildStoreUri('properties', $this->resourceId, 'terms', $this->resourceId),
+        );
+
+        return $this->sdk->propertyTerm()->get($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildStoreUri('properties', $this->resourceId, 'terms', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'property' => $this->buildStoreUri('properties', $this->resourceId),
+            'store' => $this->buildStoreUri(),
+        ];
+    }
+
+    /**
+     * @return class-string<PropertyTermResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return PropertyTermResponse::class;
+    }
+
+    /**
+     * @param PropertyTermResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals($this->buildStoreUri('properties', $this->resourceId), $response->getProperty());
+        $this->assertEquals($this->buildStoreUri(), $response->getStore());
+    }
+}

--- a/tests/Integration/Resource/PropertyTerm/UpdatePropertyTermTest.php
+++ b/tests/Integration/Resource/PropertyTerm/UpdatePropertyTermTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\PropertyTerm;
+
+use Apiera\Sdk\DTO\Request\PropertyTerm\PropertyTermRequest;
+use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestUpdateOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class UpdatePropertyTermTest extends AbstractTestUpdateOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return sprintf('/properties/%s/terms', $this->resourceId);
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::PropertyTerm->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeUpdateOperation(): PropertyTermResponse
+    {
+        $request = new PropertyTermRequest(
+            name: 'string',
+            iri: $this->buildStoreUri('properties', $this->resourceId, 'terms', $this->resourceId),
+        );
+
+        return $this->sdk->propertyTerm()->update($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildStoreUri('properties', $this->resourceId, 'terms', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'name' => 'string',
+            'property' => $this->buildStoreUri('properties', $this->resourceId),
+            'store' => $this->buildStoreUri(),
+        ];
+    }
+
+    /**
+     * @return class-string<PropertyTermResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return PropertyTermResponse::class;
+    }
+
+    /**
+     * @param PropertyTermResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getName());
+        $this->assertEquals($this->buildStoreUri('properties', $this->resourceId), $response->getProperty());
+        $this->assertEquals($this->buildStoreUri(), $response->getStore());
+    }
+}

--- a/tests/Unit/DTO/Request/PropertyTerm/PropertyTermRequestTest.php
+++ b/tests/Unit/DTO/Request/PropertyTerm/PropertyTermRequestTest.php
@@ -22,7 +22,6 @@ final class PropertyTermRequestTest extends AbstractDTORequest
         return [
             'name' => 'PropertyTerm',
             'property' => 'string',
-            'store' => 'string',
         ];
     }
 }

--- a/tests/Unit/DTO/Request/PropertyTerm/PropertyTermRequestTest.php
+++ b/tests/Unit/DTO/Request/PropertyTerm/PropertyTermRequestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\PropertyTerm;
+
+use Apiera\Sdk\DTO\Request\PropertyTerm\PropertyTermRequest;
+use Tests\Unit\DTO\Request\AbstractDTORequest;
+
+final class PropertyTermRequestTest extends AbstractDTORequest
+{
+    protected function getRequestClass(): string
+    {
+        return PropertyTermRequest::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getConstructorParams(): array
+    {
+        return [
+            'name' => 'PropertyTerm',
+            'property' => 'string',
+            'store' => 'string',
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
+++ b/tests/Unit/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\PropertyTerm;
+
+use Apiera\Sdk\DTO\Response\PartialCollectionView;
+use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOCollectionResponse;
+
+final class PropertyTermCollectionResponse extends AbstractDTOCollectionResponse
+{
+    protected function getCollectionClass(): string
+    {
+        return PropertyTermCollectionResponse::class;
+    }
+
+    protected function getMemberClass(): string
+    {
+        return PropertyTermResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getCollectionData(): array
+    {
+        $propertyTermResponse = new PropertyTermResponse(
+            ldId: '/api/v1/stores/123/products/123',
+            ldType: LdType::Product,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            name: 'PropertyTerm',
+            property: 'string',
+            store: 'string',
+        );
+
+        return [
+            'ldContext' => '/api/v1/contexts/Propertyterms',
+            'ldId' => '/api/v1/stores/123/propertyTerms',
+            'ldType' => LdType::Collection,
+            'ldMembers' => [$propertyTermResponse],
+            'ldTotalItems' => 1,
+            'ldView' => new PartialCollectionView(
+                ldId: '/api/v1/stores/123/propertyTerms?page=1',
+                ldFirst: '/api/v1/stores/123/propertyTerms?page=1',
+                ldLast: '/api/v1/stores/123/propertyTerms?page=1',
+                ldNext: null,
+                ldPrevious: null
+            ),
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
+++ b/tests/Unit/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
@@ -36,7 +36,6 @@ final class PropertyTermCollectionResponse extends AbstractDTOCollectionResponse
             updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
             name: 'PropertyTerm',
             property: 'string',
-            store: 'string',
         );
 
         return [

--- a/tests/Unit/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
+++ b/tests/Unit/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
@@ -36,6 +36,7 @@ final class PropertyTermCollectionResponse extends AbstractDTOCollectionResponse
             updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
             name: 'PropertyTerm',
             property: 'string',
+            store: '/api/v1/stores/123',
         );
 
         return [

--- a/tests/Unit/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
+++ b/tests/Unit/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
@@ -29,8 +29,8 @@ final class PropertyTermCollectionResponse extends AbstractDTOCollectionResponse
     protected function getCollectionData(): array
     {
         $propertyTermResponse = new PropertyTermResponse(
-            ldId: '/api/v1/stores/123/products/123',
-            ldType: LdType::Product,
+            ldId: '/api/v1/stores/123/properties/123/terms/123',
+            ldType: LdType::PropertyTerm,
             uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
             updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
@@ -39,15 +39,15 @@ final class PropertyTermCollectionResponse extends AbstractDTOCollectionResponse
         );
 
         return [
-            'ldContext' => '/api/v1/contexts/Propertyterms',
-            'ldId' => '/api/v1/stores/123/propertyTerms',
+            'ldContext' => '/api/v1/contexts/PropertyTerm',
+            'ldId' => '/api/v1/stores/123/properties/123/terms',
             'ldType' => LdType::Collection,
             'ldMembers' => [$propertyTermResponse],
             'ldTotalItems' => 1,
             'ldView' => new PartialCollectionView(
-                ldId: '/api/v1/stores/123/propertyTerms?page=1',
-                ldFirst: '/api/v1/stores/123/propertyTerms?page=1',
-                ldLast: '/api/v1/stores/123/propertyTerms?page=1',
+                ldId: '/api/v1/stores/123/properties/123/terms?page=1',
+                ldFirst: '/api/v1/stores/123/properties/123/terms?page=1',
+                ldLast: '/api/v1/stores/123/properties/123/terms?page=1',
                 ldNext: null,
                 ldPrevious: null
             ),

--- a/tests/Unit/DTO/Response/PropertyTerm/PropertyTermResponseTest.php
+++ b/tests/Unit/DTO/Response/PropertyTerm/PropertyTermResponseTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\PropertyTerm;
+
+use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOResponse;
+
+final class PropertyTermResponseTest extends AbstractDTOResponse
+{
+    protected function getResponseClass(): string
+    {
+        return PropertyTermResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getResponseData(): array
+    {
+        return [
+            'ldId' => '/api/v1/stores/123/products/123',
+            'ldType' => LdType::Product,
+            'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'name' => 'PropertyTerm',
+            'property' => 'string',
+            'store' => 'string',
+        ];
+    }
+
+     /**
+     * @return array<string, mixed>
+     */
+    protected function getNullableFields(): array
+    {
+        return [];
+    }
+
+    protected function getExpectedLdType(): LdType
+    {
+        return LdType::Product;
+    }
+}

--- a/tests/Unit/DTO/Response/PropertyTerm/PropertyTermResponseTest.php
+++ b/tests/Unit/DTO/Response/PropertyTerm/PropertyTermResponseTest.php
@@ -30,7 +30,6 @@ final class PropertyTermResponseTest extends AbstractDTOResponse
             'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'name' => 'PropertyTerm',
             'property' => 'string',
-            'store' => 'string',
         ];
     }
 

--- a/tests/Unit/DTO/Response/PropertyTerm/PropertyTermResponseTest.php
+++ b/tests/Unit/DTO/Response/PropertyTerm/PropertyTermResponseTest.php
@@ -30,6 +30,7 @@ final class PropertyTermResponseTest extends AbstractDTOResponse
             'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'name' => 'PropertyTerm',
             'property' => 'string',
+            'store' => '/api/v1/stores/123',
         ];
     }
 

--- a/tests/Unit/DTO/Response/PropertyTerm/PropertyTermResponseTest.php
+++ b/tests/Unit/DTO/Response/PropertyTerm/PropertyTermResponseTest.php
@@ -23,8 +23,8 @@ final class PropertyTermResponseTest extends AbstractDTOResponse
     protected function getResponseData(): array
     {
         return [
-            'ldId' => '/api/v1/stores/123/products/123',
-            'ldType' => LdType::Product,
+            'ldId' => '/api/v1/stores/123/properties/123/terms/123',
+            'ldType' => LdType::PropertyTerm,
             'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
@@ -43,6 +43,6 @@ final class PropertyTermResponseTest extends AbstractDTOResponse
 
     protected function getExpectedLdType(): LdType
     {
-        return LdType::Product;
+        return LdType::PropertyTerm;
     }
 }


### PR DESCRIPTION
---

### Description

This pull request introduces the `PropertyTermRequest`, `PropertyTermResponse`, and `PropertyTermCollectionResponse` DTOs for better structured handling of property terms. It includes integration with `PropertyTermResource` to enable CRUD operations and property term retrieval.

Additionally, unit tests were added to validate the behavior of these DTOs, ensuring accurate data structures, types, and mappings.