### PR TITLE
Add Variant resource support with DTOs and integration tests

### DIFF
--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -17,6 +17,7 @@ use Apiera\Sdk\Resource\OrganizationResource;
 use Apiera\Sdk\Resource\ProductResource;
 use Apiera\Sdk\Resource\PropertyResource;
 use Apiera\Sdk\Resource\SkuResource;
+use Apiera\Sdk\Resource\VariantResource;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
@@ -117,5 +118,12 @@ final readonly class ApieraSdk
         $dataMapper = new ReflectionAttributeDataMapper();
 
         return new SkuResource($this->client, $dataMapper);
+    }
+
+    public function variant(): VariantResource
+    {
+        $dataMapper = new ReflectionAttributeDataMapper();
+
+        return new VariantResource($this->client, $dataMapper);
     }
 }

--- a/src/DTO/Request/Variant/VariantRequest.php
+++ b/src/DTO/Request/Variant/VariantRequest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\Variant;
+
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\SkipRequest;
+use Apiera\Sdk\Enum\VariantStatus;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Transformer\VariantStatusTransformer;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class VariantRequest implements RequestInterface
+{
+    /**
+     * @param string|null $sku Sku IRI reference
+     * @param string|null $price Product price as decimal string (e.g. "99.99")
+     * @param string|null $salePrice Product sale price as decimal string (e.g. "79.99")
+     * @param string|null $weight Product weight as decimal string (e.g. "1.50")
+     * @param string|null $length Product length as decimal string (e.g. "10.00")
+     * @param string|null $width Product width as decimal string (e.g. "5.00")
+     * @param string|null $height Product height as decimal string (e.g. "2.00")
+     * @param string[] $attributeTerms Array of attribute term IRI references
+     * @param string[] $images Array of image IRI references
+     * @param string|null $product Product IRI reference (required for get collection and create operations)
+     * @param string|null $iri Resource IRI reference (required for get, update and delete operations)
+     */
+    public function __construct(
+        #[RequestField('status', VariantStatusTransformer::class)]
+        private ?VariantStatus $status = null,
+        #[RequestField('sku')]
+        private ?string $sku = null,
+        #[RequestField('price')]
+        private ?string $price = null,
+        #[RequestField('salePrice')]
+        private ?string $salePrice = null,
+        #[RequestField('description')]
+        private ?string $description = null,
+        #[RequestField('weight')]
+        private ?string $weight = null,
+        #[RequestField('length')]
+        private ?string $length = null,
+        #[RequestField('width')]
+        private ?string $width = null,
+        #[RequestField('height')]
+        private ?string $height = null,
+        #[RequestField('attributeTerms')]
+        private array $attributeTerms = [],
+        #[RequestField('images')]
+        private array $images = [],
+        #[RequestField('product')]
+        private ?string $product = null,
+        #[SkipRequest]
+        private ?string $iri = null,
+    ) {
+    }
+
+    public function getStatus(): ?VariantStatus
+    {
+        return $this->status;
+    }
+
+    public function getSku(): ?string
+    {
+        return $this->sku;
+    }
+
+    public function getPrice(): ?string
+    {
+        return $this->price;
+    }
+
+    public function getSalePrice(): ?string
+    {
+        return $this->salePrice;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getWeight(): ?string
+    {
+        return $this->weight;
+    }
+
+    public function getLength(): ?string
+    {
+        return $this->length;
+    }
+
+    public function getWidth(): ?string
+    {
+        return $this->width;
+    }
+
+    public function getHeight(): ?string
+    {
+        return $this->height;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAttributeTerms(): array
+    {
+        return $this->attributeTerms;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getImages(): array
+    {
+        return $this->images;
+    }
+
+    public function getProduct(): ?string
+    {
+        return $this->product;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status,
+            'sku' => $this->sku,
+            'attributeTerms' => $this->attributeTerms,
+            'images' => $this->images,
+            'price' => $this->price,
+            'salePrice' => $this->salePrice,
+            'description' => $this->description,
+            'weight' => $this->weight,
+            'length' => $this->length,
+            'width' => $this->width,
+            'height' => $this->height,
+        ];
+    }
+}

--- a/src/DTO/Response/Variant/VariantCollectionResponse.php
+++ b/src/DTO/Response/Variant/VariantCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Variant;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class VariantCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<VariantResponse>
+     */
+    public function getLdMembers(): array
+    {
+        /** @var array<VariantResponse> $members */
+        $members = parent::getLdMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/Variant/VariantResponse.php
+++ b/src/DTO/Response/Variant/VariantResponse.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Variant;
+
+use Apiera\Sdk\Attribute\JsonLdResponseField;
+use Apiera\Sdk\Attribute\ResponseField;
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Enum\VariantStatus;
+use Apiera\Sdk\Transformer\DateTimeTransformer;
+use Apiera\Sdk\Transformer\LdTypeTransformer;
+use Apiera\Sdk\Transformer\UuidTransformer;
+use Apiera\Sdk\Transformer\VariantStatusTransformer;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class VariantResponse extends AbstractResponse
+{
+    /**
+     * @param string[] $attributeTerms
+     * @param string[] $images
+     */
+    public function __construct(
+        #[JsonLdResponseField('@id')]
+        private string $ldId,
+        #[JsonLdResponseField('@type', LdTypeTransformer::class)]
+        private LdType $ldType,
+        #[ResponseField('uuid', UuidTransformer::class)]
+        private Uuid $uuid,
+        #[ResponseField('createdAt', DateTimeTransformer::class)]
+        private DateTimeInterface $createdAt,
+        #[ResponseField('updatedAt', DateTimeTransformer::class)]
+        private DateTimeInterface $updatedAt,
+        #[ResponseField('status', VariantStatusTransformer::class)]
+        private VariantStatus $status,
+        #[ResponseField('store')]
+        private string $store,
+        #[ResponseField('product')]
+        private string $product,
+        #[ResponseField('sku')]
+        private string $sku,
+        #[ResponseField('price', null)]
+        private ?string $price = null,
+        #[ResponseField('salePrice', null)]
+        private ?string $salePrice = null,
+        #[ResponseField('description', null)]
+        private ?string $description = null,
+        #[ResponseField('weight', null)]
+        private ?string $weight = null,
+        #[ResponseField('length', null)]
+        private ?string $length = null,
+        #[ResponseField('width', null)]
+        private ?string $width = null,
+        #[ResponseField('height', null)]
+        private ?string $height = null,
+        #[ResponseField('attributeTerms')]
+        private array $attributeTerms = [],
+        #[ResponseField('images')]
+        private array $images = [],
+    ) {
+        parent::__construct(
+            $this->ldId,
+            $this->ldType,
+            $this->uuid,
+            $this->createdAt,
+            $this->updatedAt
+        );
+    }
+
+    public function getId(): string
+    {
+        return $this->ldId;
+    }
+
+    public function getType(): LdType
+    {
+        return $this->ldType;
+    }
+
+    public function getUuid(): Uuid
+    {
+        return $this->uuid;
+    }
+
+    public function getCreatedAt(): DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function getStatus(): VariantStatus
+    {
+        return $this->status;
+    }
+
+    public function getStore(): string
+    {
+        return $this->store;
+    }
+
+    public function getProduct(): string
+    {
+        return $this->product;
+    }
+
+    public function getSku(): string
+    {
+        return $this->sku;
+    }
+
+    public function getPrice(): ?string
+    {
+        return $this->price;
+    }
+
+    public function getSalePrice(): ?string
+    {
+        return $this->salePrice;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getWeight(): ?string
+    {
+        return $this->weight;
+    }
+
+    public function getLength(): ?string
+    {
+        return $this->length;
+    }
+
+    public function getWidth(): ?string
+    {
+        return $this->width;
+    }
+
+    public function getHeight(): ?string
+    {
+        return $this->height;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAttributeTerms(): array
+    {
+        return $this->attributeTerms;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getImages(): array
+    {
+        return $this->images;
+    }
+}

--- a/src/Enum/LdType.php
+++ b/src/Enum/LdType.php
@@ -28,6 +28,8 @@ use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
 use Apiera\Sdk\DTO\Response\Sku\SkuCollectionResponse;
 use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
+use Apiera\Sdk\DTO\Response\Variant\VariantCollectionResponse;
+use Apiera\Sdk\DTO\Response\Variant\VariantResponse;
 use Exception;
 use InvalidArgumentException;
 
@@ -112,13 +114,16 @@ enum LdType: string
                 ResponseType::Single->value => SkuResponse::class,
                 ResponseType::Collection->value => SkuCollectionResponse::class,
             ],
+            self::Variant => [
+                ResponseType::Single->value => VariantResponse::class,
+                ResponseType::Collection->value => VariantCollectionResponse::class,
+            ],
             self::Integration,
             self::IntegrationResourceMap,
             self::Inventory,
             self::PropertyTerm,
             self::Store,
-            self::Tag,
-            self::Variant => throw new Exception('To be implemented'),
+            self::Tag => throw new Exception('To be implemented'),
             self::Collection => throw new InvalidArgumentException(
                 'Collection type cannot be mapped directly'
             ),

--- a/src/Enum/VariantStatus.php
+++ b/src/Enum/VariantStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Enum;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+enum VariantStatus: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}

--- a/src/Resource/VariantResource.php
+++ b/src/Resource/VariantResource.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\Variant\VariantRequest;
+use Apiera\Sdk\DTO\Response\Variant\VariantCollectionResponse;
+use Apiera\Sdk\DTO\Response\Variant\VariantResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class VariantResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/variants';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function find(RequestInterface $request, ?QueryParameters $params = null): VariantCollectionResponse
+    {
+        if (!$request instanceof VariantRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', VariantRequest::class)
+            );
+        }
+
+        if (!$request->getProduct()) {
+            throw new InvalidRequestException('Product IRI is required for this operation');
+        }
+
+        /** @var VariantCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get($request->getProduct() . self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): VariantResponse
+    {
+        if (!$request instanceof Variantrequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', VariantRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getLdTotalItems() < 1) {
+            throw new InvalidRequestException('No variant found matching the given criteria');
+        }
+
+        return $collection->getLdMembers()[0];
+    }
+
+        /**
+         * @throws InvalidRequestException
+         * @throws \Apiera\Sdk\Exception\Http\ApiException
+         * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+         */
+    public function get(RequestInterface $request): VariantResponse
+    {
+        if (!$request instanceof VariantRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', VariantRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Variant IRI is required for this operation');
+        }
+
+        /** @var VariantResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+        /**
+         * @throws InvalidRequestException
+         * @throws \Apiera\Sdk\Exception\Http\ApiException
+         * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+         */
+    public function create(RequestInterface $request): VariantResponse
+    {
+        if (!$request instanceof VariantRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', VariantRequest::class)
+            );
+        }
+
+        if (!$request->getProduct()) {
+            throw new InvalidRequestException('Product IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var VariantResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post($request->getProduct() . self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+        /**
+         * @throws InvalidRequestException
+         * @throws \Apiera\Sdk\Exception\Http\ApiException
+         * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+         */
+    public function update(RequestInterface $request): VariantResponse
+    {
+        if (!$request instanceof VariantRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', VariantRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Variant IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var VariantResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+        /**
+         * @throws InvalidRequestException
+         * @throws \Apiera\Sdk\Exception\Http\ApiException
+         */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof VariantRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', VariantRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Variant IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/src/Transformer/VariantStatusTransformer.php
+++ b/src/Transformer/VariantStatusTransformer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Transformer;
+
+use Apiera\Sdk\Enum\VariantStatus;
+use Apiera\Sdk\Exception\TransformationException;
+use Apiera\Sdk\Interface\TransformerInterface;
+use Throwable;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final class VariantStatusTransformer implements TransformerInterface
+{
+    /**
+     * @throws TransformationException
+     *
+     * @param string $data VariantStatus string
+     */
+    public function transform(mixed $data): VariantStatus
+    {
+        try {
+            return VariantStatus::from($data);
+        } catch (Throwable $exception) {
+            throw new TransformationException('Invalid VariantStatus', previous: $exception);
+        }
+    }
+
+    /**
+     * @throws TransformationException
+     */
+    public function reverseTransform(mixed $data): string
+    {
+        if (!$data instanceof VariantStatus) {
+            throw new TransformationException('Expected VariantStatus');
+        }
+
+        return $data->value;
+    }
+}

--- a/tests/Integration/Resource/Variant/DeleteVariantTest.php
+++ b/tests/Integration/Resource/Variant/DeleteVariantTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Variant;
+
+use Apiera\Sdk\DTO\Request\Variant\VariantRequest;
+use Apiera\Sdk\Enum\LdType;
+use Tests\Integration\Resource\AbstractTestDeleteOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class DeleteVariantTest extends AbstractTestDeleteOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return sprintf('/products/%s/variants', $this->resourceId);
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Variant->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    protected function executeDeleteOperation(): void
+    {
+        $request = new VariantRequest(
+            iri: $this->buildStoreUri('products', $this->resourceId, 'variants', $this->resourceId),
+        );
+
+        $this->sdk->variant()->delete($request);
+    }
+}

--- a/tests/Integration/Resource/Variant/GetVariantTest.php
+++ b/tests/Integration/Resource/Variant/GetVariantTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Variant;
+
+use Apiera\Sdk\DTO\Request\Variant\VariantRequest;
+use Apiera\Sdk\DTO\Response\Variant\VariantResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Enum\VariantStatus;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestGetOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class GetVariantTest extends AbstractTestGetOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return sprintf('/products/%s/variants', $this->resourceId);
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Variant->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeGetOperation(): VariantResponse
+    {
+        $request = new VariantRequest(
+            iri: $this->buildStoreUri('products', $this->resourceId, 'variants', $this->resourceId),
+        );
+
+        return $this->sdk->variant()->get($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildStoreUri('products', $this->resourceId, 'variants', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'price' => '100.00',
+            'salePrice' => '99.00',
+            'description' => 'Test variant description',
+            'weight' => '100.00',
+            'length' => '100.00',
+            'width' => '100.00',
+            'height' => '100.00',
+            'status' => VariantStatus::Active->value,
+            'store' => $this->buildStoreUri(),
+            'product' => $this->buildStoreUri('products', $this->resourceId),
+            'sku' => $this->buildUri('skus', $this->resourceId),
+            'attributeTerms' => [$this->buildStoreUri('attributes', $this->resourceId, 'terms', $this->resourceId)],
+            'images' => [$this->buildUri('files', $this->resourceId)],
+        ];
+    }
+
+    /**
+     * @return class-string<VariantResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return VariantResponse::class;
+    }
+
+    /**
+     * @param VariantResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('100.00', $response->getPrice());
+        $this->assertEquals('99.00', $response->getSalePrice());
+        $this->assertEquals('Test variant description', $response->getDescription());
+        $this->assertEquals('100.00', $response->getWeight());
+        $this->assertEquals('100.00', $response->getLength());
+        $this->assertEquals('100.00', $response->getWidth());
+        $this->assertEquals('100.00', $response->getHeight());
+        $this->assertEquals(VariantStatus::Active, $response->getStatus());
+        $this->assertEquals($this->buildStoreUri(), $response->getStore());
+        $this->assertEquals($this->buildStoreUri('products', $this->resourceId), $response->getProduct());
+        $this->assertEquals($this->buildUri('skus', $this->resourceId), $response->getSku());
+        $this->assertEquals(
+            [$this->buildStoreUri('attributes', $this->resourceId, 'terms', $this->resourceId)],
+            $response->getAttributeTerms()
+        );
+        $this->assertEquals([$this->buildUri('files', $this->resourceId)], $response->getImages());
+    }
+}

--- a/tests/Integration/Resource/Variant/UpdateVariantTest.php
+++ b/tests/Integration/Resource/Variant/UpdateVariantTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Variant;
+
+use Apiera\Sdk\DTO\Request\Variant\VariantRequest;
+use Apiera\Sdk\DTO\Response\Variant\VariantResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Enum\VariantStatus;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestUpdateOperation;
+use Tests\Integration\Resource\StoreScopedOperationTrait;
+
+final class UpdateVariantTest extends AbstractTestUpdateOperation
+{
+    use StoreScopedOperationTrait;
+
+    protected function getStoreScopedResourcePath(): string
+    {
+        return sprintf('/products/%s/variants', $this->resourceId);
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Variant->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeUpdateOperation(): VariantResponse
+    {
+        $request = new VariantRequest(
+            status: VariantStatus::Active,
+            sku: '/api/v1/skus/123',
+            price: '100.00',
+            salePrice: '99.00',
+            description: 'Description',
+            weight: '100.00',
+            length: '100.00',
+            width: '100.00',
+            height: '100.00',
+            attributeTerms: [
+                '/api/v1/stores/123/attributes/123/terms/456',
+            ],
+            images: [
+                '/api/v1/files/123',
+            ],
+            iri: $this->buildStoreUri('products', $this->resourceId, 'variants', $this->resourceId),
+        );
+
+        return $this->sdk->variant()->update($request);
+    }
+
+    /**
+     * @return class-string<VariantResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return VariantResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildStoreUri('products', $this->resourceId, 'variants', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'price' => '100.00',
+            'salePrice' => '99.00',
+            'description' => 'Test variant description',
+            'weight' => '100.00',
+            'length' => '100.00',
+            'width' => '100.00',
+            'height' => '100.00',
+            'status' => VariantStatus::Active->value,
+            'store' => $this->buildStoreUri(),
+            'product' => $this->buildStoreUri('products', $this->resourceId),
+            'sku' => $this->buildUri('skus', $this->resourceId),
+            'attributeTerms' => [$this->buildStoreUri('attributes', $this->resourceId, 'terms', $this->resourceId)],
+            'images' => [$this->buildUri('files', $this->resourceId)],
+        ];
+    }
+
+    /**
+     * @param VariantResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('100.00', $response->getPrice());
+        $this->assertEquals('99.00', $response->getSalePrice());
+        $this->assertEquals('Test variant description', $response->getDescription());
+        $this->assertEquals('100.00', $response->getWeight());
+        $this->assertEquals('100.00', $response->getLength());
+        $this->assertEquals('100.00', $response->getWidth());
+        $this->assertEquals('100.00', $response->getHeight());
+        $this->assertEquals(VariantStatus::Active, $response->getStatus());
+        $this->assertEquals($this->buildStoreUri(), $response->getStore());
+        $this->assertEquals($this->buildStoreUri('products', $this->resourceId), $response->getProduct());
+        $this->assertEquals($this->buildUri('skus', $this->resourceId), $response->getSku());
+        $this->assertEquals(
+            [$this->buildStoreUri('attributes', $this->resourceId, 'terms', $this->resourceId)],
+            $response->getAttributeTerms()
+        );
+        $this->assertEquals([$this->buildUri('files', $this->resourceId)], $response->getImages());
+    }
+}

--- a/tests/Unit/DTO/Request/Variant/VariantRequestTest.php
+++ b/tests/Unit/DTO/Request/Variant/VariantRequestTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\Variant;
+
+use Apiera\Sdk\DTO\Request\Variant\VariantRequest;
+use Apiera\Sdk\Enum\VariantStatus;
+use Tests\Unit\DTO\Request\AbstractDTORequest;
+
+final class VariantRequestTest extends AbstractDTORequest
+{
+    protected function getRequestClass(): string
+    {
+        return VariantRequest::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getConstructorParams(): array
+    {
+        return [
+            'price' => '100.00',
+            'salePrice' => '99.00',
+            'description' => 'Description',
+            'weight' => '100.00',
+            'length' => '100.00',
+            'width' => '100.00',
+            'height' => '100.00',
+            'status' => VariantStatus::Active,
+            'product' => '/api/v1/stores/123/products/123',
+            'sku' => '/api/v1/skus/123',
+            'attributeTerms' => [
+                '/api/v1/stores/123/attributes/123/terms/456',
+            ],
+            'images' => [
+                '/api/v1/files/123',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/Variant/VariantCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Variant/VariantCollectionResponseTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Variant;
+
+use Apiera\Sdk\DTO\Response\PartialCollectionView;
+use Apiera\Sdk\DTO\Response\Variant\VariantCollectionResponse;
+use Apiera\Sdk\DTO\Response\Variant\VariantResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Enum\VariantStatus;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOCollectionResponse;
+
+final class VariantCollectionResponseTest extends AbstractDTOCollectionResponse
+{
+    protected function getCollectionClass(): string
+    {
+        return VariantCollectionResponse::class;
+    }
+
+    protected function getMemberClass(): string
+    {
+        return VariantResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getCollectionData(): array
+    {
+        $variantResponse = new VariantResponse(
+            ldId: '/api/v1/stores/123/products/123/variants/123',
+            ldType: LdType::Variant,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            status: VariantStatus::Active,
+            store: '/api/v1/stores/123',
+            product: '/api/v1/stores/123/products/123',
+            sku: '/api/v1/skus/123',
+            price: '100.00',
+            salePrice: '99.00',
+            description: 'Variant description',
+            weight: '100.00',
+            length: '100.00',
+            width: '100.00',
+            height: '100.00',
+            attributeTerms:  [
+                '/api/v1/stores/123/attributes/123/terms/456',
+            ],
+            images: [
+                '/api/v1/files/123',
+            ],
+        );
+
+        return [
+            'ldContext' => '/api/v1/contexts/Variant',
+            'ldId' => '/api/v1/stores/123/products/123/variants',
+            'ldType' => LdType::Collection,
+            'ldMembers' => [$variantResponse],
+            'ldTotalItems' => 1,
+            'ldView' => new PartialCollectionView(
+                ldId: '/api/v1/stores/123/products/123/variants?page=1',
+                ldFirst: '/api/v1/stores/123/products/123/variants?page=1',
+                ldLast: '/api/v1/stores/123/products/123/variants?page=1',
+                ldNext: null,
+                ldPrevious: null
+            ),
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/Variant/VariantResponseTest.php
+++ b/tests/Unit/DTO/Response/Variant/VariantResponseTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Variant;
+
+use Apiera\Sdk\DTO\Response\Variant\VariantResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Enum\VariantStatus;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOResponse;
+
+final class VariantResponseTest extends AbstractDTOResponse
+{
+    protected function getResponseClass(): string
+    {
+        return VariantResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getResponseData(): array
+    {
+        return [
+            'ldId' => '/api/v1/stores/123/products/123/variants/123',
+            'ldType' => LdType::Variant,
+            'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'status' => VariantStatus::Active,
+            'store' => '/api/v1/stores/123',
+            'product' => '/api/v1/stores/123/products/123',
+            'sku' => '/api/v1/skus/123',
+            'price' => '100.00',
+            'salePrice' => '99.00',
+            'description' => 'Variant description',
+            'weight' => '100.00',
+            'length' => '100.00',
+            'width' => '100.00',
+            'height' => '100.00',
+            'attributeTerms' => [
+                '/api/v1/stores/123/attributes/123/terms/456',
+            ],
+            'images' => [
+                '/api/v1/files/123',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getNullableFields(): array
+    {
+        return [
+            'price' => null,
+            'salePrice' => null,
+            'description' => null,
+            'weight' => null,
+            'length' => null,
+            'width' => null,
+            'height' => null,
+        ];
+    }
+
+    protected function getExpectedLdType(): LdType
+    {
+        return LdType::Variant;
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces support for managing `Variant` resources in the SDK, including the following enhancements:
- **VariantResource**: Added methods to handle Create, Get, Update, and Delete operations on variants.
- **DTOs**:
  - `VariantRequest` for handling variant-related requests with attributes like SKU, price, dimensions, and status.
  - `VariantResponse` for managing variant-specific data and mapping.
  - `VariantCollectionResponse` for handling collections of variants with additional components such as `VariantStatus` and `VariantStatusTransformer`.
- **Unit Tests**: Included for individual DTOs to ensure proper functionality and data handling.
- **Integration Tests**: Provided to validate Create, Get, Update, and Delete operations for variants within store-scoped contexts.

These changes collectively enhance the SDK’s ability to support variant-related functionalities.