### PR TITLE
Add ResourceMap feature with DTOs, tests, and SDK integration

### DIFF
--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -17,6 +17,7 @@ use Apiera\Sdk\Resource\OrganizationResource;
 use Apiera\Sdk\Resource\ProductResource;
 use Apiera\Sdk\Resource\PropertyResource;
 use Apiera\Sdk\Resource\PropertyTermResource;
+use Apiera\Sdk\Resource\ResourceMapResource;
 use Apiera\Sdk\Resource\SkuResource;
 use Apiera\Sdk\Resource\StoreResource;
 use Apiera\Sdk\Resource\TagResource;
@@ -149,5 +150,12 @@ final readonly class ApieraSdk
         $dataMapper = new ReflectionAttributeDataMapper();
 
         return new PropertyTermResource($this->client, $dataMapper);
+    }
+
+    public function resourceMap(): ResourceMapResource
+    {
+        $dataMapper = new ReflectionAttributeDataMapper();
+
+        return new ResourceMapResource($this->client, $dataMapper);
     }
 }

--- a/src/DTO/Request/ResourceMap/ResourceMapRequest.php
+++ b/src/DTO/Request/ResourceMap/ResourceMapRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\ResourceMap;
+
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\SkipRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class ResourceMapRequest implements RequestInterface
+{
+    public function __construct(
+        #[RequestField('external')]
+        private ?string $external = null,
+        #[RequestField('resource')]
+        private ?string $resource = null,
+        #[SkipRequest]
+        private ?string $integration = null,
+        #[SkipRequest]
+        private ?string $iri = null,
+    ) {
+    }
+
+    public function getExternal(): ?string
+    {
+        return $this->external;
+    }
+
+    public function getResource(): ?string
+    {
+        return $this->resource;
+    }
+
+    public function getIntegration(): ?string
+    {
+        return $this->integration;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'external' => $this->external,
+            'resource' => $this->resource,
+        ];
+    }
+}

--- a/src/DTO/Response/ResourceMap/ResourceMapCollectionResponse.php
+++ b/src/DTO/Response/ResourceMap/ResourceMapCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\ResourceMap;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class ResourceMapCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<ResourceMapResponse>
+     */
+    public function getLdMembers(): array
+    {
+        /** @var array<ResourceMapResponse> $members */
+        $members = parent::getLdMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/ResourceMap/ResourceMapResponse.php
+++ b/src/DTO/Response/ResourceMap/ResourceMapResponse.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\ResourceMap;
+
+use Apiera\Sdk\Attribute\JsonLdResponseField;
+use Apiera\Sdk\Attribute\ResponseField;
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Transformer\DateTimeTransformer;
+use Apiera\Sdk\Transformer\LdTypeTransformer;
+use Apiera\Sdk\Transformer\UuidTransformer;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class ResourceMapResponse extends AbstractResponse
+{
+    public function __construct(
+        #[JsonLdResponseField('@id')]
+        private string $ldId,
+        #[JsonLdResponseField('@type', LdTypeTransformer::class)]
+        private LdType $ldType,
+        #[ResponseField('uuid', UuidTransformer::class)]
+        private Uuid $uuid,
+        #[ResponseField('createdAt', DateTimeTransformer::class)]
+        private DateTimeInterface $createdAt,
+        #[ResponseField('updatedAt', DateTimeTransformer::class)]
+        private DateTimeInterface $updatedAt,
+        #[ResponseField('external')]
+        private string $external,
+        #[ResponseField('internal')]
+        private string $internal,
+        #[ResponseField('resource')]
+        private string $resource,
+        #[ResponseField('resourceType')]
+        private string $resourceType,
+        #[ResponseField('integration')]
+        private string $integration,
+    ) {
+        parent::__construct(
+            $this->ldId,
+            $this->ldType,
+            $this->uuid,
+            $this->createdAt,
+            $this->updatedAt
+        );
+    }
+
+    public function getLdId(): string
+    {
+        return $this->ldId;
+    }
+
+    public function getLdType(): LdType
+    {
+        return $this->ldType;
+    }
+
+    public function getUuid(): Uuid
+    {
+        return $this->uuid;
+    }
+
+    public function getCreatedAt(): DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function getUpdatedAt(): DateTimeInterface
+    {
+        return $this->updatedAt;
+    }
+
+    public function getExternal(): string
+    {
+        return $this->external;
+    }
+
+    public function getInternal(): string
+    {
+        return $this->internal;
+    }
+
+    public function getResource(): string
+    {
+        return $this->resource;
+    }
+
+    public function getResourceType(): string
+    {
+        return $this->resourceType;
+    }
+
+    public function getIntegration(): string
+    {
+        return $this->integration;
+    }
+}

--- a/src/Enum/LdType.php
+++ b/src/Enum/LdType.php
@@ -28,6 +28,8 @@ use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
 use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermCollectionResponse;
 use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapCollectionResponse;
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapResponse;
 use Apiera\Sdk\DTO\Response\Sku\SkuCollectionResponse;
 use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
 use Apiera\Sdk\DTO\Response\Store\StoreCollectionResponse;
@@ -136,8 +138,11 @@ enum LdType: string
                 ResponseType::Single->value => PropertyTermResponse::class,
                 ResponseType::Collection->value => PropertyTermCollectionResponse::class,
             ],
+            self::IntegrationResourceMap => [
+                ResponseType::Single->value => ResourceMapResponse::class,
+                ResponseType::Collection->value => ResourceMapCollectionResponse::class,
+            ],
             self::Integration,
-            self::IntegrationResourceMap,
             self::Inventory => throw new Exception('To be implemented'),
             self::Collection => throw new InvalidArgumentException(
                 'Collection type cannot be mapped directly'

--- a/src/Resource/ResourceMapResource.php
+++ b/src/Resource/ResourceMapResource.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\ResourceMap\ResourceMapRequest;
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapCollectionResponse;
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 0.3.0
+ */
+final readonly class ResourceMapResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/mappings';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function find(RequestInterface $request, ?QueryParameters $params = null): ResourceMapCollectionResponse
+    {
+        if (!$request instanceof ResourceMapRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', ResourceMapRequest::class)
+            );
+        }
+
+        if (!$request->getIntegration()) {
+            throw new InvalidRequestException('Integration IRI is required for this operation');
+        }
+
+        /** @var ResourceMapCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get($request->getIntegration() . self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): ResourceMapResponse
+    {
+        if (!$request instanceof ResourceMapRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', ResourceMapRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getLdTotalItems() < 1) {
+            throw new InvalidRequestException('No resource map found matching the given criteria');
+        }
+
+        return $collection->getLdMembers()[0];
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function get(RequestInterface $request): ResourceMapResponse
+    {
+        if (!$request instanceof ResourceMapRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', ResourceMapRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Resource map IRI is required for this operation');
+        }
+
+        /** @var ResourceMapResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function create(RequestInterface $request): ResourceMapResponse
+    {
+        if (!$request instanceof ResourceMapRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', ResourceMapRequest::class)
+            );
+        }
+
+        if (!$request->getIntegration()) {
+            throw new InvalidRequestException('Integration IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var ResourceMapResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post($request->getIntegration() . self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function update(RequestInterface $request): ResourceMapResponse
+    {
+        if (!$request instanceof ResourceMapRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', ResourceMapRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Resource map IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var ResourceMapResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof ResourceMapRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', ResourceMapRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Resource map IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/tests/Integration/Resource/IntegrationScopedOperationTrait.php
+++ b/tests/Integration/Resource/IntegrationScopedOperationTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource;
+
+trait IntegrationScopedOperationTrait
+{
+    use ResourceOperationTrait;
+
+    protected string $integrationId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+
+    abstract protected function getIntegrationScopedResourcePath(): string;
+
+    protected function getResourcePath(): string
+    {
+        return $this->normalizePath('integrations', $this->integrationId, $this->getIntegrationScopedResourcePath());
+    }
+
+    protected function buildIntegrationUri(string ...$segments): string
+    {
+        return $this->buildUri('integrations', $this->integrationId, ...$segments);
+    }
+}

--- a/tests/Integration/Resource/ResourceMap/CreateResourceMapTest.php
+++ b/tests/Integration/Resource/ResourceMap/CreateResourceMapTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\ResourceMap;
+
+use Apiera\Sdk\DTO\Request\ResourceMap\ResourceMapRequest;
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestCreateOperation;
+use Tests\Integration\Resource\IntegrationScopedOperationTrait;
+
+final class CreateResourceMapTest extends AbstractTestCreateOperation
+{
+    use IntegrationScopedOperationTrait;
+
+    protected function getIntegrationScopedResourcePath(): string
+    {
+        return '/mappings';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::IntegrationResourceMap->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeCreateOperation(): ResourceMapResponse
+    {
+        $request = new ResourceMapRequest(
+            external: 'string',
+            resource: 'string',
+            integration: $this->buildIntegrationUri(),
+        );
+
+        return $this->sdk->resourceMap()->create($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildIntegrationUri('mappings', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'external' => 'string',
+            'internal' => 'string',
+            'resource' => 'string',
+            'resourceType' => 'string',
+            'integration' => '/api/v1/integrations/123',
+        ];
+    }
+
+    /**
+     * @return class-string<ResourceMapResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return ResourceMapResponse::class;
+    }
+
+    /**
+     * @param ResourceMapResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getExternal());
+        $this->assertEquals('string', $response->getInternal());
+        $this->assertEquals('string', $response->getResource());
+        $this->assertEquals('string', $response->getResourceType());
+        $this->assertEquals('/api/v1/integrations/123', $response->getIntegration());
+    }
+}

--- a/tests/Integration/Resource/ResourceMap/DeleteResourceMapTest.php
+++ b/tests/Integration/Resource/ResourceMap/DeleteResourceMapTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\ResourceMap;
+
+use Apiera\Sdk\DTO\Request\ResourceMap\ResourceMapRequest;
+use Apiera\Sdk\Enum\LdType;
+use Tests\Integration\Resource\AbstractTestDeleteOperation;
+use Tests\Integration\Resource\IntegrationScopedOperationTrait;
+
+final class DeleteResourceMapTest extends AbstractTestDeleteOperation
+{
+    use IntegrationScopedOperationTrait;
+
+    protected function getIntegrationScopedResourcePath(): string
+    {
+        return '/mappings';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::IntegrationResourceMap->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    protected function executeDeleteOperation(): void
+    {
+        $request = new ResourceMapRequest(
+            iri: $this->buildIntegrationUri('mappings', $this->resourceId)
+        );
+
+        $this->sdk->resourceMap()->delete($request);
+    }
+}

--- a/tests/Integration/Resource/ResourceMap/GetResourceMapTest.php
+++ b/tests/Integration/Resource/ResourceMap/GetResourceMapTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\ResourceMap;
+
+use Apiera\Sdk\DTO\Request\ResourceMap\ResourceMapRequest;
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestGetOperation;
+use Tests\Integration\Resource\IntegrationScopedOperationTrait;
+
+final class GetResourceMapTest extends AbstractTestGetOperation
+{
+    use IntegrationScopedOperationTrait;
+
+    protected function getIntegrationScopedResourcePath(): string
+    {
+        return '/mappings';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::IntegrationResourceMap->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeGetOperation(): ResourceMapResponse
+    {
+        $request = new ResourceMapRequest(
+            iri: $this->buildIntegrationUri('mappings', $this->resourceId),
+        );
+
+        return $this->sdk->resourceMap()->get($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildIntegrationUri('mappings', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'external' => 'string',
+            'internal' => 'string',
+            'resource' => 'string',
+            'resourceType' => 'string',
+            'integration' => '/api/v1/integrations/123',
+        ];
+    }
+
+    /**
+     * @return class-string<ResourceMapResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return ResourceMapResponse::class;
+    }
+
+    /**
+     * @param ResourceMapResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getExternal());
+        $this->assertEquals('string', $response->getInternal());
+        $this->assertEquals('string', $response->getResource());
+        $this->assertEquals('string', $response->getResourceType());
+        $this->assertEquals('/api/v1/integrations/123', $response->getIntegration());
+    }
+}

--- a/tests/Integration/Resource/ResourceMap/UpdateResourceMapTest.php
+++ b/tests/Integration/Resource/ResourceMap/UpdateResourceMapTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\ResourceMap;
+
+use Apiera\Sdk\DTO\Request\ResourceMap\ResourceMapRequest;
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestUpdateOperation;
+use Tests\Integration\Resource\IntegrationScopedOperationTrait;
+
+final class UpdateResourceMapTest extends AbstractTestUpdateOperation
+{
+    use IntegrationScopedOperationTrait;
+
+    protected function getIntegrationScopedResourcePath(): string
+    {
+        return '/mappings';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::IntegrationResourceMap->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeUpdateOperation(): ResourceMapResponse
+    {
+        $request = new ResourceMapRequest(
+            external: 'string',
+            resource: 'string',
+            iri: $this->buildIntegrationUri('mappings', $this->resourceId),
+        );
+
+        return $this->sdk->resourceMap()->update($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildIntegrationUri('mappings', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'external' => 'string',
+            'internal' => 'string',
+            'resource' => 'string',
+            'resourceType' => 'string',
+            'integration' => '/api/v1/integrations/123',
+        ];
+    }
+
+    /**
+     * @return class-string<ResourceMapResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return ResourceMapResponse::class;
+    }
+
+    /**
+     * @param ResourceMapResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals('string', $response->getExternal());
+        $this->assertEquals('string', $response->getInternal());
+        $this->assertEquals('string', $response->getResource());
+        $this->assertEquals('string', $response->getResourceType());
+        $this->assertEquals('/api/v1/integrations/123', $response->getIntegration());
+    }
+}

--- a/tests/Unit/DTO/Request/ResourceMap/ResourceMapRequestTest.php
+++ b/tests/Unit/DTO/Request/ResourceMap/ResourceMapRequestTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\ResourceMap;
+
+use Apiera\Sdk\DTO\Request\ResourceMap\ResourceMapRequest;
+use Tests\Unit\DTO\Request\AbstractDTORequest;
+
+final class ResourceMapRequestTest extends AbstractDTORequest
+{
+    protected function getRequestClass(): string
+    {
+        return ResourceMapRequest::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getConstructorParams(): array
+    {
+        return [
+            'external' => 'string',
+            'resource' => 'string',
+            'integration' => 'string',
+            'iri' => 'string',
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/ResourceMap/ResourceMapCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/ResourceMap/ResourceMapCollectionResponseTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\ResourceMap;
+
+use Apiera\Sdk\DTO\Response\PartialCollectionView;
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapCollectionResponse;
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOCollectionResponse;
+
+final class ResourceMapCollectionResponseTest extends AbstractDTOCollectionResponse
+{
+    protected function getCollectionClass(): string
+    {
+        return ResourceMapCollectionResponse::class;
+    }
+
+    protected function getMemberClass(): string
+    {
+        return ResourceMapResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getCollectionData(): array
+    {
+        $resourceMapResponse = new ResourceMapResponse(
+            ldId: '/api/v1/integrations/123/mappings/123',
+            ldType: LdType::IntegrationResourceMap,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            external: 'string',
+            internal: 'string',
+            resource: 'string',
+            resourceType: 'string',
+            integration: '/api/v1/integrations/123',
+        );
+
+        return [
+            'ldContext' => '/api/v1/contexts/IntegrationResourceMap',
+            'ldId' => '/api/v1/integrations/123/mappings',
+            'ldType' => LdType::Collection,
+            'ldMembers' => [$resourceMapResponse],
+            'ldTotalItems' => 1,
+            'ldView' => new PartialCollectionView(
+                ldId: '/api/v1/integrations/123/mappings?page=1',
+                ldFirst: '/api/v1/integrations/123/mappings?page=1',
+                ldLast: '/api/v1/integrations/123/mappings?page=1',
+                ldNext: null,
+                ldPrevious: null
+            ),
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/ResourceMap/ResourceMapResponseTest.php
+++ b/tests/Unit/DTO/Response/ResourceMap/ResourceMapResponseTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\ResourceMap;
+
+use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOResponse;
+
+final class ResourceMapResponseTest extends AbstractDTOResponse
+{
+    protected function getResponseClass(): string
+    {
+        return ResourceMapResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getResponseData(): array
+    {
+        return [
+            'ldId' => '/api/v1/integrations/123/mappings/123',
+            'ldType' => LdType::IntegrationResourceMap,
+            'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'external' => 'string',
+            'internal' => 'string',
+            'resource' => 'string',
+            'resourceType' => 'string',
+            'integration' => '/api/v1/integrations/123',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getNullableFields(): array
+    {
+        return [];
+    }
+
+    protected function getExpectedLdType(): LdType
+    {
+        return LdType::IntegrationResourceMap;
+    }
+}


### PR DESCRIPTION
This pull request introduces the `ResourceMap` feature with comprehensive support in the SDK. Changes include:

- **Added `ResourceMapRequest` DTO**: Represents resource mapping requests with attributes like `external`, `resource`, `integration`, and `iri`. Includes unit tests for validation.
- **Added `ResourceMapResponse` DTO**: Handles resource mapping responses. Includes unit tests to ensure correctness and compatibility.
- **Added `ResourceMapCollectionResponse`**: Manages collections of resource mappings, extending `AbstractCollectionResponse`. Includes unit tests for validation.
- **Added `ResourceMapResource` to SDK**: Provides CRUD operations (`find`, `get`, `create`, `update`, `delete`) for resource mappings, integrated into `LdType` and `ApieraSdk`.
- **Integration Tests**: Tests cover Create, Get, Update, and Delete operations for `ResourceMap`, ensuring functionality and stability. A reusable `IntegrationScopedOperationTrait` aids in operation handling. 