### PR TITLE
Add Inventory feature with request/response handling and tests

### DIFF
--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -13,6 +13,7 @@ use Apiera\Sdk\Resource\CategoryResource;
 use Apiera\Sdk\Resource\DistributorResource;
 use Apiera\Sdk\Resource\FileResource;
 use Apiera\Sdk\Resource\InventoryLocationResource;
+use Apiera\Sdk\Resource\InventoryResource;
 use Apiera\Sdk\Resource\OrganizationResource;
 use Apiera\Sdk\Resource\ProductResource;
 use Apiera\Sdk\Resource\PropertyResource;
@@ -150,6 +151,13 @@ final readonly class ApieraSdk
         $dataMapper = new ReflectionAttributeDataMapper();
 
         return new PropertyTermResource($this->client, $dataMapper);
+    }
+
+    public function inventory(): InventoryResource
+    {
+        $dataMapper = new ReflectionAttributeDataMapper();
+
+        return new InventoryResource($this->client, $dataMapper);
     }
 
     public function resourceMap(): ResourceMapResource

--- a/src/DTO/Request/Inventory/InventoryRequest.php
+++ b/src/DTO/Request/Inventory/InventoryRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Request\Inventory;
+
+use Apiera\Sdk\Attribute\RequestField;
+use Apiera\Sdk\Attribute\SkipRequest;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class InventoryRequest implements RequestInterface
+{
+    public function __construct(
+        #[RequestField('quantity')]
+        private ?int $quantity = null,
+        #[RequestField('sku')]
+        private ?string $sku = null,
+        #[RequestField('inventoryLocation')]
+        private ?string $inventoryLocation = null,
+        #[SkipRequest]
+        private ?string $iri = null,
+    ) {
+    }
+
+    public function getQuantity(): ?int
+    {
+        return $this->quantity;
+    }
+
+    public function getSku(): ?string
+    {
+        return $this->sku;
+    }
+
+    public function getInventoryLocation(): ?string
+    {
+        return $this->inventoryLocation;
+    }
+
+    public function getIri(): ?string
+    {
+        return $this->iri;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'quantity' => $this->quantity,
+            'sku' => $this->sku,
+            'inventoryLocation' => $this->inventoryLocation,
+        ];
+    }
+}

--- a/src/DTO/Response/Inventory/InventoryCollectionResponse.php
+++ b/src/DTO/Response/Inventory/InventoryCollectionResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Inventory;
+
+use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class InventoryCollectionResponse extends AbstractCollectionResponse
+{
+    /**
+     * @return array<InventoryResponse>
+     */
+    public function getLdMembers(): array
+    {
+        /** @var array<InventoryResponse> $members */
+        $members = parent::getLdMembers();
+
+        return $members;
+    }
+}

--- a/src/DTO/Response/Inventory/InventoryResponse.php
+++ b/src/DTO/Response/Inventory/InventoryResponse.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\DTO\Response\Inventory;
+
+use Apiera\Sdk\Attribute\JsonLdResponseField;
+use Apiera\Sdk\Attribute\ResponseField;
+use Apiera\Sdk\DTO\Response\AbstractResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Transformer\DateTimeTransformer;
+use Apiera\Sdk\Transformer\LdTypeTransformer;
+use Apiera\Sdk\Transformer\UuidTransformer;
+use DateTimeInterface;
+use Symfony\Component\Uid\Uuid;
+
+/**
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class InventoryResponse extends AbstractResponse
+{
+    public function __construct(
+        #[JsonLdResponseField('@id')]
+        private string $ldId,
+        #[JsonLdResponseField('@type', LdTypeTransformer::class)]
+        private LdType $ldType,
+        #[ResponseField('uuid', UuidTransformer::class)]
+        private Uuid $uuid,
+        #[ResponseField('createdAt', DateTimeTransformer::class)]
+        private DateTimeInterface $createdAt,
+        #[ResponseField('updatedAt', DateTimeTransformer::class)]
+        private DateTimeInterface $updatedAt,
+        #[ResponseField('quantity')]
+        private int $quantity,
+        #[ResponseField('sku')]
+        private string $sku,
+        #[ResponseField('inventoryLocation')]
+        private string $inventoryLocation,
+    ) {
+        parent::__construct(
+            $this->ldId,
+            $this->ldType,
+            $this->uuid,
+            $this->createdAt,
+            $this->updatedAt
+        );
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function getSku(): string
+    {
+        return $this->sku;
+    }
+
+    public function getInventoryLocation(): string
+    {
+        return $this->inventoryLocation;
+    }
+}

--- a/src/Enum/LdType.php
+++ b/src/Enum/LdType.php
@@ -18,6 +18,8 @@ use Apiera\Sdk\DTO\Response\Distributor\DistributorCollectionResponse;
 use Apiera\Sdk\DTO\Response\Distributor\DistributorResponse;
 use Apiera\Sdk\DTO\Response\File\FileCollectionResponse;
 use Apiera\Sdk\DTO\Response\File\FileResponse;
+use Apiera\Sdk\DTO\Response\Inventory\InventoryCollectionResponse;
+use Apiera\Sdk\DTO\Response\Inventory\InventoryResponse;
 use Apiera\Sdk\DTO\Response\InventoryLocation\InventoryLocationCollectionResponse;
 use Apiera\Sdk\DTO\Response\InventoryLocation\InventoryLocationResponse;
 use Apiera\Sdk\DTO\Response\Organization\OrganizationCollectionResponse;
@@ -138,12 +140,15 @@ enum LdType: string
                 ResponseType::Single->value => PropertyTermResponse::class,
                 ResponseType::Collection->value => PropertyTermCollectionResponse::class,
             ],
+            self::Inventory => [
+                ResponseType::Single->value => InventoryResponse::class,
+                ResponseType::Collection->value => InventoryCollectionResponse::class,
+            ],
             self::IntegrationResourceMap => [
                 ResponseType::Single->value => ResourceMapResponse::class,
                 ResponseType::Collection->value => ResourceMapCollectionResponse::class,
             ],
-            self::Integration,
-            self::Inventory => throw new Exception('To be implemented'),
+            self::Integration => throw new Exception('To be implemented'),
             self::Collection => throw new InvalidArgumentException(
                 'Collection type cannot be mapped directly'
             ),

--- a/src/Resource/InventoryResource.php
+++ b/src/Resource/InventoryResource.php
@@ -33,10 +33,8 @@ final readonly class InventoryResource implements RequestResourceInterface
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
-    public function find(
-        RequestInterface $request,
-        ?QueryParameters $params = null
-    ): InventoryCollectionResponse {
+    public function find(RequestInterface $request, ?QueryParameters $params = null): InventoryCollectionResponse
+    {
         if (!$request instanceof InventoryRequest) {
             throw new InvalidRequestException(
                 sprintf('Request must be an instance of %s', InventoryRequest::class)

--- a/src/Resource/InventoryResource.php
+++ b/src/Resource/InventoryResource.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Resource;
+
+use Apiera\Sdk\DTO\QueryParameters;
+use Apiera\Sdk\DTO\Request\Inventory\InventoryRequest;
+use Apiera\Sdk\DTO\Response\Inventory\InventoryCollectionResponse;
+use Apiera\Sdk\DTO\Response\Inventory\InventoryResponse;
+use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\DataMapperInterface;
+use Apiera\Sdk\Interface\DTO\RequestInterface;
+use Apiera\Sdk\Interface\RequestResourceInterface;
+
+/**int
+ * @author Marie Rinden <marie@shoppingnorge.no>
+ * @since 0.3.0
+ */
+final readonly class InventoryResource implements RequestResourceInterface
+{
+    private const string ENDPOINT = '/inventories';
+
+    public function __construct(
+        private ClientInterface $client,
+        private DataMapperInterface $mapper,
+    ) {
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function find(
+        RequestInterface $request,
+        ?QueryParameters $params = null
+    ): InventoryCollectionResponse {
+        if (!$request instanceof InventoryRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', InventoryRequest::class)
+            );
+        }
+
+        if (!$request->getInventoryLocation()) {
+            throw new InvalidRequestException('Inventory location IRI is required for this operation');
+        }
+
+        /** @var InventoryCollectionResponse $collectionResponse */
+        $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
+            $this->client->get($request->getInventoryLocation() . self::ENDPOINT, $params)
+        ));
+
+        return $collectionResponse;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function findOneBy(RequestInterface $request, QueryParameters $params): InventoryResponse
+    {
+        if (!$request instanceof InventoryRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', InventoryRequest::class)
+            );
+        }
+
+        $collection = $this->find($request, $params);
+
+        if ($collection->getLdTotalItems() < 1) {
+            throw new InvalidRequestException('No inventory found matching the given criteria');
+        }
+
+        return $collection->getLdMembers()[0];
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function get(RequestInterface $request): InventoryResponse
+    {
+        if (!$request instanceof InventoryRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', InventoryRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Inventory IRI is required for this operation');
+        }
+
+        /** @var InventoryResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->get($request->getIri())
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function create(RequestInterface $request): InventoryResponse
+    {
+        if (!$request instanceof InventoryRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', InventoryRequest::class)
+            );
+        }
+
+        if (!$request->getInventoryLocation()) {
+            throw new InvalidRequestException('Inventory location IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var InventoryResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->post($request->getInventoryLocation() . self::ENDPOINT, $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    public function update(RequestInterface $request): InventoryResponse
+    {
+        if (!$request instanceof InventoryRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', InventoryRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Inventory IRI is required for this operation');
+        }
+
+        $requestData = $this->mapper->toRequestData($request);
+
+        /** @var InventoryResponse $response */
+        $response = $this->mapper->fromResponse($this->client->decodeResponse(
+            $this->client->patch($request->getIri(), $requestData)
+        ));
+
+        return $response;
+    }
+
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    public function delete(RequestInterface $request): void
+    {
+        if (!$request instanceof InventoryRequest) {
+            throw new InvalidRequestException(
+                sprintf('Request must be an instance of %s', InventoryRequest::class)
+            );
+        }
+
+        if (!$request->getIri()) {
+            throw new InvalidRequestException('Inventory IRI is required for this operation');
+        }
+
+        $this->client->delete($request->getIri());
+    }
+}

--- a/tests/Integration/Resource/Inventory/CreateInventoryTest.php
+++ b/tests/Integration/Resource/Inventory/CreateInventoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Inventory;
+
+use Apiera\Sdk\DTO\Request\Inventory\InventoryRequest;
+use Apiera\Sdk\DTO\Response\Inventory\InventoryResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestCreateOperation;
+use Tests\Integration\Resource\InventoryLocationScopedTrait;
+
+final class CreateInventoryTest extends AbstractTestCreateOperation
+{
+    use InventoryLocationScopedTrait;
+
+    protected function getInventoryLocationScopedResourcePath(): string
+    {
+        return '/inventories';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Inventory->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeCreateOperation(): InventoryResponse
+    {
+        $request = new InventoryRequest(
+            quantity: 100,
+            sku: $this->buildUri('skus', $this->resourceId),
+            inventoryLocation: $this->buildIntegrationUri()
+        );
+
+        return $this->sdk->inventory()->create($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildIntegrationUri('inventories', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'quantity' => 100,
+            'sku' => $this->buildUri('skus', $this->resourceId),
+            'inventoryLocation' => $this->buildIntegrationUri(),
+        ];
+    }
+
+    /**
+     * @return class-string<InventoryResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return InventoryResponse::class;
+    }
+
+    /**
+     * @param InventoryResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals(100, $response->getQuantity());
+        $this->assertEquals($this->buildUri('skus', $this->resourceId), $response->getSku());
+        $this->assertEquals($this->buildIntegrationUri(), $response->getInventoryLocation());
+    }
+}

--- a/tests/Integration/Resource/Inventory/DeleteInventoryTest.php
+++ b/tests/Integration/Resource/Inventory/DeleteInventoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Inventory;
+
+use Apiera\Sdk\DTO\Request\Inventory\InventoryRequest;
+use Apiera\Sdk\Enum\LdType;
+use Tests\Integration\Resource\AbstractTestDeleteOperation;
+use Tests\Integration\Resource\InventoryLocationScopedTrait;
+
+final class DeleteInventoryTest extends AbstractTestDeleteOperation
+{
+    use InventoryLocationScopedTrait;
+
+    protected function getInventoryLocationScopedResourcePath(): string
+    {
+        return '/inventories';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Inventory->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     */
+    protected function executeDeleteOperation(): void
+    {
+        $request = new InventoryRequest(
+            iri: $this->buildIntegrationUri('inventories', $this->resourceId)
+        );
+
+        $this->sdk->inventory()->delete($request);
+    }
+}

--- a/tests/Integration/Resource/Inventory/GetInventoryTest.php
+++ b/tests/Integration/Resource/Inventory/GetInventoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Inventory;
+
+use Apiera\Sdk\DTO\Request\Inventory\InventoryRequest;
+use Apiera\Sdk\DTO\Response\Inventory\InventoryResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestGetOperation;
+use Tests\Integration\Resource\InventoryLocationScopedTrait;
+
+final class GetInventoryTest extends AbstractTestGetOperation
+{
+    use InventoryLocationScopedTrait;
+
+    protected function getInventoryLocationScopedResourcePath(): string
+    {
+        return '/inventories';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Inventory->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
+    protected function executeGetOperation(): InventoryResponse
+    {
+        $request = new InventoryRequest(
+            iri: $this->buildIntegrationUri('inventories', $this->resourceId)
+        );
+
+        return $this->sdk->inventory()->get($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildIntegrationUri('inventories', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'quantity' => 100,
+            'sku' => $this->buildUri('skus', $this->resourceId),
+            'inventoryLocation' => $this->buildIntegrationUri(),
+        ];
+    }
+
+    /**
+     * @return class-string<InventoryResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return InventoryResponse::class;
+    }
+
+    /**
+     * @param InventoryResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals(100, $response->getQuantity());
+        $this->assertEquals($this->buildUri('skus', $this->resourceId), $response->getSku());
+        $this->assertEquals($this->buildIntegrationUri(), $response->getInventoryLocation());
+    }
+}

--- a/tests/Integration/Resource/Inventory/UpdateInventoryTest.php
+++ b/tests/Integration/Resource/Inventory/UpdateInventoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource\Inventory;
+
+use Apiera\Sdk\DTO\Request\Inventory\InventoryRequest;
+use Apiera\Sdk\DTO\Response\Inventory\InventoryResponse;
+use Apiera\Sdk\Enum\LdType;
+use Apiera\Sdk\Interface\DTO\ResponseInterface;
+use Tests\Integration\Resource\AbstractTestUpdateOperation;
+use Tests\Integration\Resource\InventoryLocationScopedTrait;
+
+final class UpdateInventoryTest extends AbstractTestUpdateOperation
+{
+    use InventoryLocationScopedTrait;
+
+    protected function getInventoryLocationScopedResourcePath(): string
+    {
+        return '/inventories';
+    }
+
+    protected function getResourceType(): string
+    {
+        return LdType::Inventory->value;
+    }
+
+    /**
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     * @throws \Apiera\Sdk\Exception\InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
+    protected function executeUpdateOperation(): InventoryResponse
+    {
+        $request = new InventoryRequest(
+            quantity: 100,
+            sku: $this->buildUri('skus', $this->resourceId),
+            iri: $this->buildIntegrationUri('inventories', $this->resourceId)
+        );
+
+        return $this->sdk->inventory()->update($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getMockResponseData(): array
+    {
+        return [
+            '@id' => $this->buildIntegrationUri('inventories', $this->resourceId),
+            '@type' => $this->getResourceType(),
+            'uuid' => $this->resourceId,
+            'createdAt' => self::CREATED_AT,
+            'updatedAt' => self::UPDATED_AT,
+            'quantity' => 100,
+            'sku' => $this->buildUri('skus', $this->resourceId),
+            'inventoryLocation' => $this->buildIntegrationUri(),
+        ];
+    }
+
+    /**
+     * @return class-string<InventoryResponse>
+     */
+    protected function getResponseClass(): string
+    {
+        return InventoryResponse::class;
+    }
+
+    /**
+     * @param InventoryResponse $response
+     */
+    protected function assertResourceSpecificFields(ResponseInterface $response): void
+    {
+        $this->assertEquals(100, $response->getQuantity());
+        $this->assertEquals($this->buildUri('skus', $this->resourceId), $response->getSku());
+        $this->assertEquals($this->buildIntegrationUri(), $response->getInventoryLocation());
+    }
+}

--- a/tests/Integration/Resource/InventoryLocationScopedTrait.php
+++ b/tests/Integration/Resource/InventoryLocationScopedTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Resource;
+
+trait InventoryLocationScopedTrait
+{
+    use ResourceOperationTrait;
+
+    protected string $inventoryLocationId = '9d024f41-3faf-4eef-9d2d-a7e506b81afb';
+
+    abstract protected function getInventoryLocationScopedResourcePath(): string;
+
+    protected function getResourcePath(): string
+    {
+        return $this->normalizePath(
+            'inventory_locations',
+            $this->inventoryLocationId,
+            $this->getInventoryLocationScopedResourcePath()
+        );
+    }
+
+    protected function buildIntegrationUri(string ...$segments): string
+    {
+        return $this->buildUri('inventory_locations', $this->inventoryLocationId, ...$segments);
+    }
+}

--- a/tests/Unit/DTO/Request/Inventory/InventoryRequestTest.php
+++ b/tests/Unit/DTO/Request/Inventory/InventoryRequestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Request\Inventory;
+
+use Apiera\Sdk\DTO\Request\Inventory\InventoryRequest;
+use Tests\Unit\DTO\Request\AbstractDTORequest;
+
+final class InventoryRequestTest extends AbstractDTORequest
+{
+    protected function getRequestClass(): string
+    {
+        return InventoryRequest::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getConstructorParams(): array
+    {
+        return [
+            'quantity' => 0,
+            'sku' => '/api/v1/skus/123',
+            'inventoryLocation' => '/api/v1/inventory_locations/123',
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/Inventory/InventoryCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Inventory/InventoryCollectionResponseTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Inventory;
+
+use Apiera\Sdk\DTO\Response\Inventory\InventoryCollectionResponse;
+use Apiera\Sdk\DTO\Response\Inventory\InventoryResponse;
+use Apiera\Sdk\DTO\Response\PartialCollectionView;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOCollectionResponse;
+
+final class InventoryCollectionResponseTest extends AbstractDTOCollectionResponse
+{
+    protected function getCollectionClass(): string
+    {
+        return InventoryCollectionResponse::class;
+    }
+
+    protected function getMemberClass(): string
+    {
+        return InventoryResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getCollectionData(): array
+    {
+        $inventoryResponse = new InventoryResponse(
+            ldId: '/api/v1/inventory_locations/123/inventories',
+            ldType: LdType::Inventory,
+            uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            updatedAt: new DateTimeImmutable('2021-01-01 00:00:00'),
+            quantity: 0,
+            sku: '/api/v1/skus/123',
+            inventoryLocation: '/api/v1/inventory_locations/123',
+        );
+
+        return [
+            'ldContext' => '/api/v1/contexts/Inventory',
+            'ldId' => '/api/v1/inventory_locations/123/inventories',
+            'ldType' => LdType::Collection,
+            'ldMembers' => [$inventoryResponse],
+            'ldTotalItems' => 1,
+            'ldView' => new PartialCollectionView(
+                ldId: '/api/v1/inventory_locations/123/inventories?page=1',
+                ldFirst: '/api/v1/inventory_locations/123/inventories?page=1',
+                ldLast: '/api/v1/inventory_locations/123/inventories?page=1',
+                ldNext: null,
+                ldPrevious: null
+            ),
+        ];
+    }
+}

--- a/tests/Unit/DTO/Response/Inventory/InventoryCollectionResponseTest.php
+++ b/tests/Unit/DTO/Response/Inventory/InventoryCollectionResponseTest.php
@@ -30,7 +30,7 @@ final class InventoryCollectionResponseTest extends AbstractDTOCollectionRespons
     protected function getCollectionData(): array
     {
         $inventoryResponse = new InventoryResponse(
-            ldId: '/api/v1/inventory_locations/123/inventories',
+            ldId: '/api/v1/inventory_locations/123/inventories/123',
             ldType: LdType::Inventory,
             uuid: Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             createdAt: new DateTimeImmutable('2021-01-01 00:00:00'),

--- a/tests/Unit/DTO/Response/Inventory/InventoryResponseTest.php
+++ b/tests/Unit/DTO/Response/Inventory/InventoryResponseTest.php
@@ -23,8 +23,8 @@ final class InventoryResponseTest extends AbstractDTOResponse
     protected function getResponseData(): array
     {
         return [
-            'ldId' => '/api/v1/stores/123/tags/123',
-            'ldType' => LdType::Tag,
+            'ldId' => '/api/v1/inventory_locations/123/inventories/123',
+            'ldType' => LdType::Inventory,
             'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
             'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
             'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
@@ -44,6 +44,6 @@ final class InventoryResponseTest extends AbstractDTOResponse
 
     protected function getExpectedLdType(): LdType
     {
-        return LdType::Tag;
+        return LdType::Inventory;
     }
 }

--- a/tests/Unit/DTO/Response/Inventory/InventoryResponseTest.php
+++ b/tests/Unit/DTO/Response/Inventory/InventoryResponseTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\DTO\Response\Inventory;
+
+use Apiera\Sdk\DTO\Response\Inventory\InventoryResponse;
+use Apiera\Sdk\Enum\LdType;
+use DateTimeImmutable;
+use Symfony\Component\Uid\Uuid;
+use Tests\Unit\DTO\Response\AbstractDTOResponse;
+
+final class InventoryResponseTest extends AbstractDTOResponse
+{
+    protected function getResponseClass(): string
+    {
+        return InventoryResponse::class;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getResponseData(): array
+    {
+        return [
+            'ldId' => '/api/v1/stores/123/tags/123',
+            'ldType' => LdType::Tag,
+            'uuid' => Uuid::fromString('bfd2639c-7793-426a-a413-ea262e582208'),
+            'createdAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'updatedAt' => new DateTimeImmutable('2021-01-01 00:00:00'),
+            'quantity' => 0,
+            'sku' => '/api/v1/skus/123',
+            'inventoryLocation' => '/api/v1/inventory_locations/123',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getNullableFields(): array
+    {
+        return [];
+    }
+
+    protected function getExpectedLdType(): LdType
+    {
+        return LdType::Tag;
+    }
+}


### PR DESCRIPTION
### Description

This pull request includes the following changes:

- **Removed unused DataMappers and tests**: Deleted `AttributeTermDataMapper` and `InventoryDataMapper` along with their related tests as they are no longer in use. Updated `InventoryRequest` and `InventoryResponse` classes to adopt attributes for request and response handling, aligning with current conventions.
- **Refactored inventory handling**: Enforced required fields (`quantity`, `sku`, `inventoryLocation`) in DTOs and tests. Adjusted `InventoryResource` to include validation for `inventoryLocation` and fixed endpoint paths. Removed outdated test cases for better maintainability.
- **Fixed missing trailing commas**: Corrected data entries in `InventoryResourceTest`.
- **Added integration tests**: Comprehensive integration tests for `InventoryResource` covering CRUD functionalities, authentication, and response parsing.
- **Extended unit test coverage**: Included new unit tests for `InventoryResource`, `InventoryDataMapper`, `InventoryCollectionResponse`, `InventoryRequest`, and `InventoryResponse` to enhance reliability and code coverage.