### PR TITLE
Update version annotations to 1.0.0**

### DIFF
--- a/src/Attribute/JsonLdResponseField.php
+++ b/src/Attribute/JsonLdResponseField.php
@@ -9,7 +9,7 @@ use Attribute;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final readonly class JsonLdResponseField implements ResponseFieldInterface

--- a/src/Attribute/RequestField.php
+++ b/src/Attribute/RequestField.php
@@ -9,7 +9,7 @@ use Attribute;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final readonly class RequestField implements RequestFieldInterface

--- a/src/Attribute/ResponseField.php
+++ b/src/Attribute/ResponseField.php
@@ -9,7 +9,7 @@ use Attribute;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final readonly class ResponseField implements ResponseFieldInterface

--- a/src/Attribute/SkipRequest.php
+++ b/src/Attribute/SkipRequest.php
@@ -8,7 +8,7 @@ use Attribute;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 #[Attribute(Attribute::TARGET_PROPERTY)]
 final readonly class SkipRequest

--- a/src/DTO/Request/AttributeTerm/AttributeTermRequest.php
+++ b/src/DTO/Request/AttributeTerm/AttributeTermRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class AttributeTermRequest implements RequestInterface
 {

--- a/src/DTO/Request/Brand/BrandRequest.php
+++ b/src/DTO/Request/Brand/BrandRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class BrandRequest implements RequestInterface
 {

--- a/src/DTO/Request/Distributor/DistributorRequest.php
+++ b/src/DTO/Request/Distributor/DistributorRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class DistributorRequest implements RequestInterface
 {

--- a/src/DTO/Request/File/FileRequest.php
+++ b/src/DTO/Request/File/FileRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class FileRequest implements RequestInterface
 {

--- a/src/DTO/Request/Inventory/InventoryRequest.php
+++ b/src/DTO/Request/Inventory/InventoryRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class InventoryRequest implements RequestInterface
 {

--- a/src/DTO/Request/InventoryLocation/InventoryLocationRequest.php
+++ b/src/DTO/Request/InventoryLocation/InventoryLocationRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class InventoryLocationRequest implements RequestInterface
 {

--- a/src/DTO/Request/Organization/OrganizationRequest.php
+++ b/src/DTO/Request/Organization/OrganizationRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class OrganizationRequest implements RequestInterface
 {

--- a/src/DTO/Request/Product/ProductRequest.php
+++ b/src/DTO/Request/Product/ProductRequest.php
@@ -14,7 +14,7 @@ use Apiera\Sdk\Transformer\ProductTypeTransformer;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class ProductRequest implements RequestInterface
 {

--- a/src/DTO/Request/Property/PropertyRequest.php
+++ b/src/DTO/Request/Property/PropertyRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class PropertyRequest implements RequestInterface
 {

--- a/src/DTO/Request/PropertyTerm/PropertyTermRequest.php
+++ b/src/DTO/Request/PropertyTerm/PropertyTermRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class PropertyTermRequest implements RequestInterface
 {

--- a/src/DTO/Request/ResourceMap/ResourceMapRequest.php
+++ b/src/DTO/Request/ResourceMap/ResourceMapRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class ResourceMapRequest implements RequestInterface
 {

--- a/src/DTO/Request/Sku/SkuRequest.php
+++ b/src/DTO/Request/Sku/SkuRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class SkuRequest implements RequestInterface
 {

--- a/src/DTO/Request/Store/StoreRequest.php
+++ b/src/DTO/Request/Store/StoreRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class StoreRequest implements RequestInterface
 {

--- a/src/DTO/Request/Tag/TagRequest.php
+++ b/src/DTO/Request/Tag/TagRequest.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\DTO\RequestInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class TagRequest implements RequestInterface
 {

--- a/src/DTO/Request/Variant/VariantRequest.php
+++ b/src/DTO/Request/Variant/VariantRequest.php
@@ -12,7 +12,7 @@ use Apiera\Sdk\Transformer\VariantStatusTransformer;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class VariantRequest implements RequestInterface
 {

--- a/src/DTO/Response/AttributeTerm/AttributeTermCollectionResponse.php
+++ b/src/DTO/Response/AttributeTerm/AttributeTermCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class AttributeTermCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/AttributeTerm/AttributeTermResponse.php
+++ b/src/DTO/Response/AttributeTerm/AttributeTermResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class AttributeTermResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Brand/BrandCollectionResponse.php
+++ b/src/DTO/Response/Brand/BrandCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
 */
 final readonly class BrandCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Brand/BrandResponse.php
+++ b/src/DTO/Response/Brand/BrandResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class BrandResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Distributor/DistributorCollectionResponse.php
+++ b/src/DTO/Response/Distributor/DistributorCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class DistributorCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Distributor/DistributorResponse.php
+++ b/src/DTO/Response/Distributor/DistributorResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class DistributorResponse extends AbstractResponse
 {

--- a/src/DTO/Response/File/FileCollectionResponse.php
+++ b/src/DTO/Response/File/FileCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class FileCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/File/FileResponse.php
+++ b/src/DTO/Response/File/FileResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class FileResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Inventory/InventoryCollectionResponse.php
+++ b/src/DTO/Response/Inventory/InventoryCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class InventoryCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Inventory/InventoryResponse.php
+++ b/src/DTO/Response/Inventory/InventoryResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class InventoryResponse extends AbstractResponse
 {

--- a/src/DTO/Response/InventoryLocation/InventoryLocationCollectionResponse.php
+++ b/src/DTO/Response/InventoryLocation/InventoryLocationCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class InventoryLocationCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/InventoryLocation/InventoryLocationResponse.php
+++ b/src/DTO/Response/InventoryLocation/InventoryLocationResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class InventoryLocationResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Organization/OrganizationCollectionResponse.php
+++ b/src/DTO/Response/Organization/OrganizationCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class OrganizationCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Organization/OrganizationResponse.php
+++ b/src/DTO/Response/Organization/OrganizationResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class OrganizationResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Product/ProductCollectionResponse.php
+++ b/src/DTO/Response/Product/ProductCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class ProductCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Product/ProductResponse.php
+++ b/src/DTO/Response/Product/ProductResponse.php
@@ -20,7 +20,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class ProductResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Property/PropertyCollectionResponse.php
+++ b/src/DTO/Response/Property/PropertyCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class PropertyCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Property/PropertyResponse.php
+++ b/src/DTO/Response/Property/PropertyResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class PropertyResponse extends AbstractResponse
 {

--- a/src/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
+++ b/src/DTO/Response/PropertyTerm/PropertyTermCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class PropertyTermCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/PropertyTerm/PropertyTermResponse.php
+++ b/src/DTO/Response/PropertyTerm/PropertyTermResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class PropertyTermResponse extends AbstractResponse
 {

--- a/src/DTO/Response/ResourceMap/ResourceMapCollectionResponse.php
+++ b/src/DTO/Response/ResourceMap/ResourceMapCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class ResourceMapCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/ResourceMap/ResourceMapResponse.php
+++ b/src/DTO/Response/ResourceMap/ResourceMapResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class ResourceMapResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Sku/SkuCollectionResponse.php
+++ b/src/DTO/Response/Sku/SkuCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class SkuCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Sku/SkuResponse.php
+++ b/src/DTO/Response/Sku/SkuResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class SkuResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Store/StoreCollectionResponse.php
+++ b/src/DTO/Response/Store/StoreCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class StoreCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Store/StoreResponse.php
+++ b/src/DTO/Response/Store/StoreResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class StoreResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Tag/TagCollectionResponse.php
+++ b/src/DTO/Response/Tag/TagCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class TagCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Tag/TagResponse.php
+++ b/src/DTO/Response/Tag/TagResponse.php
@@ -16,7 +16,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class TagResponse extends AbstractResponse
 {

--- a/src/DTO/Response/Variant/VariantCollectionResponse.php
+++ b/src/DTO/Response/Variant/VariantCollectionResponse.php
@@ -8,7 +8,7 @@ use Apiera\Sdk\DTO\Response\AbstractCollectionResponse;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class VariantCollectionResponse extends AbstractCollectionResponse
 {

--- a/src/DTO/Response/Variant/VariantResponse.php
+++ b/src/DTO/Response/Variant/VariantResponse.php
@@ -18,7 +18,7 @@ use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class VariantResponse extends AbstractResponse
 {

--- a/src/DataMapper/ReflectionAttributeDataMapper.php
+++ b/src/DataMapper/ReflectionAttributeDataMapper.php
@@ -22,7 +22,7 @@ use Throwable;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class ReflectionAttributeDataMapper implements DataMapperInterface
 {

--- a/src/Enum/ProductStatus.php
+++ b/src/Enum/ProductStatus.php
@@ -6,7 +6,7 @@ namespace Apiera\Sdk\Enum;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 enum ProductStatus: string
 {

--- a/src/Enum/ProductType.php
+++ b/src/Enum/ProductType.php
@@ -6,7 +6,7 @@ namespace Apiera\Sdk\Enum;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 enum ProductType: string
 {

--- a/src/Enum/ResponseType.php
+++ b/src/Enum/ResponseType.php
@@ -6,7 +6,7 @@ namespace Apiera\Sdk\Enum;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 enum ResponseType: string
 {

--- a/src/Enum/VariantStatus.php
+++ b/src/Enum/VariantStatus.php
@@ -6,7 +6,7 @@ namespace Apiera\Sdk\Enum;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 enum VariantStatus: string
 {

--- a/src/Exception/CacheException.php
+++ b/src/Exception/CacheException.php
@@ -6,7 +6,7 @@ namespace Apiera\Sdk\Exception;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class CacheException extends \Exception
 {

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -8,7 +8,7 @@ use Exception;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class ConfigurationException extends Exception
 {

--- a/src/Exception/Http/ApiException.php
+++ b/src/Exception/Http/ApiException.php
@@ -13,7 +13,7 @@ use Throwable;
  * Base exception for all HTTP/API related errors
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 abstract class ApiException extends Exception
 {

--- a/src/Exception/Http/AuthenticationException.php
+++ b/src/Exception/Http/AuthenticationException.php
@@ -12,7 +12,7 @@ use Throwable;
  * 401/403 Authentication/Authorization errors
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class AuthenticationException extends ApiException
 {

--- a/src/Exception/Http/BadRequestException.php
+++ b/src/Exception/Http/BadRequestException.php
@@ -12,7 +12,7 @@ use Throwable;
  * 400 Bad Request errors
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class BadRequestException extends ApiException
 {

--- a/src/Exception/Http/GenericHttpException.php
+++ b/src/Exception/Http/GenericHttpException.php
@@ -12,7 +12,7 @@ use Throwable;
  * Used for HTTP errors that don't fit into other specific categories
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class GenericHttpException extends ApiException
 {

--- a/src/Exception/Http/NotFoundException.php
+++ b/src/Exception/Http/NotFoundException.php
@@ -12,7 +12,7 @@ use Throwable;
  * 404 Not Found errors
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class NotFoundException extends ApiException
 {

--- a/src/Exception/Http/ServerException.php
+++ b/src/Exception/Http/ServerException.php
@@ -12,7 +12,7 @@ use Throwable;
  * 500 Server errors
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class ServerException extends ApiException
 {

--- a/src/Exception/Http/UnprocessableEntityException.php
+++ b/src/Exception/Http/UnprocessableEntityException.php
@@ -12,7 +12,7 @@ use Throwable;
  * 422 Validation errors
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class UnprocessableEntityException extends ApiException
 {

--- a/src/Exception/Mapping/MappingException.php
+++ b/src/Exception/Mapping/MappingException.php
@@ -11,7 +11,7 @@ use Throwable;
  * Base exception for all mapping-related errors
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 abstract class MappingException extends Exception
 {

--- a/src/Exception/Mapping/RequestMappingException.php
+++ b/src/Exception/Mapping/RequestMappingException.php
@@ -11,7 +11,7 @@ use Throwable;
  * Thrown when unable to map request DTO to API data
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class RequestMappingException extends MappingException
 {

--- a/src/Exception/Mapping/ResponseMappingException.php
+++ b/src/Exception/Mapping/ResponseMappingException.php
@@ -10,7 +10,7 @@ use Throwable;
  * Thrown when unable to map response data to DTO
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class ResponseMappingException extends MappingException
 {

--- a/src/Exception/NotSupportedOperationException.php
+++ b/src/Exception/NotSupportedOperationException.php
@@ -10,7 +10,7 @@ use Exception;
  * Exception thrown when attempting to use an unsupported operation.
  *
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class NotSupportedOperationException extends Exception
 {

--- a/src/Exception/TransformationException.php
+++ b/src/Exception/TransformationException.php
@@ -6,7 +6,7 @@ namespace Apiera\Sdk\Exception;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class TransformationException extends \Exception
 {

--- a/src/Factory/ApiExceptionFactory.php
+++ b/src/Factory/ApiExceptionFactory.php
@@ -17,7 +17,7 @@ use Throwable;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class ApiExceptionFactory
 {

--- a/src/Factory/ResourceFactory.php
+++ b/src/Factory/ResourceFactory.php
@@ -10,7 +10,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class ResourceFactory
 {

--- a/src/Interface/RequestFieldInterface.php
+++ b/src/Interface/RequestFieldInterface.php
@@ -6,7 +6,7 @@ namespace Apiera\Sdk\Interface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 interface RequestFieldInterface
 {

--- a/src/Interface/ResponseFieldInterface.php
+++ b/src/Interface/ResponseFieldInterface.php
@@ -6,7 +6,7 @@ namespace Apiera\Sdk\Interface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 interface ResponseFieldInterface
 {

--- a/src/Interface/TransformerInterface.php
+++ b/src/Interface/TransformerInterface.php
@@ -6,7 +6,7 @@ namespace Apiera\Sdk\Interface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 interface TransformerInterface
 {

--- a/src/Resource/AttributeTermResource.php
+++ b/src/Resource/AttributeTermResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class AttributeTermResource implements RequestResourceInterface
 {

--- a/src/Resource/BrandResource.php
+++ b/src/Resource/BrandResource.php
@@ -17,7 +17,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class BrandResource implements RequestResourceInterface
 {

--- a/src/Resource/DistributorResource.php
+++ b/src/Resource/DistributorResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class DistributorResource implements RequestResourceInterface
 {

--- a/src/Resource/FileResource.php
+++ b/src/Resource/FileResource.php
@@ -17,7 +17,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class FileResource implements RequestResourceInterface
 {

--- a/src/Resource/InventoryLocationResource.php
+++ b/src/Resource/InventoryLocationResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class InventoryLocationResource implements RequestResourceInterface
 {

--- a/src/Resource/InventoryResource.php
+++ b/src/Resource/InventoryResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**int
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class InventoryResource implements RequestResourceInterface
 {

--- a/src/Resource/OrganizationResource.php
+++ b/src/Resource/OrganizationResource.php
@@ -17,7 +17,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class OrganizationResource implements RequestResourceInterface
 {

--- a/src/Resource/ProductResource.php
+++ b/src/Resource/ProductResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class ProductResource implements RequestResourceInterface
 {

--- a/src/Resource/PropertyResource.php
+++ b/src/Resource/PropertyResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class PropertyResource implements RequestResourceInterface
 {

--- a/src/Resource/PropertyTermResource.php
+++ b/src/Resource/PropertyTermResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class PropertyTermResource implements RequestResourceInterface
 {

--- a/src/Resource/ResourceMapResource.php
+++ b/src/Resource/ResourceMapResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class ResourceMapResource implements RequestResourceInterface
 {

--- a/src/Resource/SkuResource.php
+++ b/src/Resource/SkuResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class SkuResource implements RequestResourceInterface
 {

--- a/src/Resource/StoreResource.php
+++ b/src/Resource/StoreResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class StoreResource implements RequestResourceInterface
 {

--- a/src/Resource/TagResource.php
+++ b/src/Resource/TagResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnoge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class TagResource implements RequestResourceInterface
 {

--- a/src/Resource/VariantResource.php
+++ b/src/Resource/VariantResource.php
@@ -16,7 +16,7 @@ use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final readonly class VariantResource implements RequestResourceInterface
 {

--- a/src/Transformer/DateTimeTransformer.php
+++ b/src/Transformer/DateTimeTransformer.php
@@ -12,7 +12,7 @@ use Throwable;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class DateTimeTransformer implements TransformerInterface
 {

--- a/src/Transformer/LdTypeTransformer.php
+++ b/src/Transformer/LdTypeTransformer.php
@@ -11,7 +11,7 @@ use Throwable;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class LdTypeTransformer implements TransformerInterface
 {

--- a/src/Transformer/ProductStatusTransformer.php
+++ b/src/Transformer/ProductStatusTransformer.php
@@ -11,7 +11,7 @@ use Throwable;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class ProductStatusTransformer implements TransformerInterface
 {

--- a/src/Transformer/ProductTypeTransformer.php
+++ b/src/Transformer/ProductTypeTransformer.php
@@ -11,7 +11,7 @@ use Throwable;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class ProductTypeTransformer implements TransformerInterface
 {

--- a/src/Transformer/UuidTransformer.php
+++ b/src/Transformer/UuidTransformer.php
@@ -11,7 +11,7 @@ use Throwable;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class UuidTransformer implements TransformerInterface
 {

--- a/src/Transformer/VariantStatusTransformer.php
+++ b/src/Transformer/VariantStatusTransformer.php
@@ -11,7 +11,7 @@ use Throwable;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
- * @since 0.3.0
+ * @since 1.0.0
  */
 final class VariantStatusTransformer implements TransformerInterface
 {


### PR DESCRIPTION
Updated all `@since` version annotations throughout the codebase from 0.3.0 to 1.0.0. This aligns documentation with the new major release and ensures consistency with semantic versioning practices.