### PR TITLE
Add validation for multiple results in findOneBy method 

### DIFF
--- a/src/Exception/MultipleResourcesFoundException.php
+++ b/src/Exception/MultipleResourcesFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Exception;
+
+use Exception;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 2.0.0
+ */
+final class MultipleResourcesFoundException extends Exception
+{
+}

--- a/src/Exception/ResourceNotFoundException.php
+++ b/src/Exception/ResourceNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Exception;
+
+use Exception;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 2.0.0
+ */
+final class ResourceNotFoundException extends Exception
+{
+}

--- a/src/Resource/AlternateIdentifierResource.php
+++ b/src/Resource/AlternateIdentifierResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\AlternateIdentifier\AlternateIdentifierRequest;
 use Apiera\Sdk\DTO\Response\AlternateIdentifier\AlternateIdentifierCollectionResponse;
 use Apiera\Sdk\DTO\Response\AlternateIdentifier\AlternateIdentifierResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -53,6 +55,8 @@ final readonly class AlternateIdentifierResource implements RequestResourceInter
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -67,7 +71,15 @@ final readonly class AlternateIdentifierResource implements RequestResourceInter
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No alternate identifier found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No alternate identifier found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple alternate identifiers found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/AttributeResource.php
+++ b/src/Resource/AttributeResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Attribute\AttributeRequest;
 use Apiera\Sdk\DTO\Response\Attribute\AttributeCollectionResponse;
 use Apiera\Sdk\DTO\Response\Attribute\AttributeResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class AttributeResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class AttributeResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No attribute found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No attribute found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple attributes found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/AttributeTermResource.php
+++ b/src/Resource/AttributeTermResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest;
 use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermCollectionResponse;
 use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class AttributeTermResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class AttributeTermResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No attribute term found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No attribute term found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple attribute terms found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/BrandResource.php
+++ b/src/Resource/BrandResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Brand\BrandRequest;
 use Apiera\Sdk\DTO\Response\Brand\BrandCollectionResponse;
 use Apiera\Sdk\DTO\Response\Brand\BrandResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -58,6 +60,8 @@ final readonly class BrandResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -72,7 +76,15 @@ final readonly class BrandResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No brand found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No brand found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple brands found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/CategoryResource.php
+++ b/src/Resource/CategoryResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Category\CategoryRequest;
 use Apiera\Sdk\DTO\Response\Category\CategoryCollectionResponse;
 use Apiera\Sdk\DTO\Response\Category\CategoryResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class CategoryResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class CategoryResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No category found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No category found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple categories found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/DistributorResource.php
+++ b/src/Resource/DistributorResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Distributor\DistributorRequest;
 use Apiera\Sdk\DTO\Response\Distributor\DistributorCollectionResponse;
 use Apiera\Sdk\DTO\Response\Distributor\DistributorResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class DistributorResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class DistributorResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No distributor found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No distributor found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple distributors found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/FileResource.php
+++ b/src/Resource/FileResource.php
@@ -9,7 +9,9 @@ use Apiera\Sdk\DTO\Request\File\FileRequest;
 use Apiera\Sdk\DTO\Response\File\FileCollectionResponse;
 use Apiera\Sdk\DTO\Response\File\FileResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\NotSupportedOperationException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -52,6 +54,8 @@ final readonly class FileResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -66,7 +70,15 @@ final readonly class FileResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No file found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No file found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple files found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/InventoryLocationResource.php
+++ b/src/Resource/InventoryLocationResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\InventoryLocation\InventoryLocationRequest;
 use Apiera\Sdk\DTO\Response\InventoryLocation\InventoryLocationCollectionResponse;
 use Apiera\Sdk\DTO\Response\InventoryLocation\InventoryLocationResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -53,6 +55,8 @@ final readonly class InventoryLocationResource implements RequestResourceInterfa
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -67,7 +71,15 @@ final readonly class InventoryLocationResource implements RequestResourceInterfa
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No inventory location found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No inventory location found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple inventory locations found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/InventoryResource.php
+++ b/src/Resource/InventoryResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Inventory\InventoryRequest;
 use Apiera\Sdk\DTO\Response\Inventory\InventoryCollectionResponse;
 use Apiera\Sdk\DTO\Response\Inventory\InventoryResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class InventoryResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class InventoryResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No inventory found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No inventory found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple inventories found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/OrganizationResource.php
+++ b/src/Resource/OrganizationResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Organization\OrganizationRequest;
 use Apiera\Sdk\DTO\Response\Organization\OrganizationCollectionResponse;
 use Apiera\Sdk\DTO\Response\Organization\OrganizationResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -52,6 +54,8 @@ final readonly class OrganizationResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -66,7 +70,15 @@ final readonly class OrganizationResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No organization found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No organization found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple organizations found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/ProductResource.php
+++ b/src/Resource/ProductResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Product\ProductRequest;
 use Apiera\Sdk\DTO\Response\Product\ProductCollectionResponse;
 use Apiera\Sdk\DTO\Response\Product\ProductResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class ProductResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class ProductResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No product found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No product found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple products found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/PropertyResource.php
+++ b/src/Resource/PropertyResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Property\PropertyRequest;
 use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class PropertyResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class PropertyResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No property found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No property found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple properties found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/PropertyTermResource.php
+++ b/src/Resource/PropertyTermResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\PropertyTerm\PropertyTermRequest;
 use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermCollectionResponse;
 use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class PropertyTermResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class PropertyTermResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No property term found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No property term found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple property terms found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/ResourceMapResource.php
+++ b/src/Resource/ResourceMapResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\ResourceMap\ResourceMapRequest;
 use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapCollectionResponse;
 use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class ResourceMapResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class ResourceMapResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No resource map found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No resource map found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple resource maps found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/SkuResource.php
+++ b/src/Resource/SkuResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Sku\SkuRequest;
 use Apiera\Sdk\DTO\Response\Sku\SkuCollectionResponse;
 use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -51,6 +53,8 @@ final readonly class SkuResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -65,7 +69,15 @@ final readonly class SkuResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No sku found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No sku found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple skus found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/StoreResource.php
+++ b/src/Resource/StoreResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Store\StoreRequest;
 use Apiera\Sdk\DTO\Response\Store\StoreCollectionResponse;
 use Apiera\Sdk\DTO\Response\Store\StoreResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -51,6 +53,8 @@ final readonly class StoreResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -65,7 +69,15 @@ final readonly class StoreResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No store found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No store found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple stores found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/TagResource.php
+++ b/src/Resource/TagResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Tag\TagRequest;
 use Apiera\Sdk\DTO\Response\Tag\TagCollectionResponse;
 use Apiera\Sdk\DTO\Response\Tag\TagResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class TagResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class TagResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No tag found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No tag found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple tags found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/VariantResource.php
+++ b/src/Resource/VariantResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Variant\VariantRequest;
 use Apiera\Sdk\DTO\Response\Variant\VariantCollectionResponse;
 use Apiera\Sdk\DTO\Response\Variant\VariantResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class VariantResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,17 +73,25 @@ final readonly class VariantResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No variant found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No variant found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple variants found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];
     }
 
-        /**
-         * @throws InvalidRequestException
-         * @throws \Apiera\Sdk\Exception\Http\ApiException
-         * @throws \Apiera\Sdk\Exception\Mapping\MappingException
-         */
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
     public function get(RequestInterface $request): VariantResponse
     {
         if (!$request instanceof VariantRequest) {
@@ -100,11 +112,11 @@ final readonly class VariantResource implements RequestResourceInterface
         return $response;
     }
 
-        /**
-         * @throws InvalidRequestException
-         * @throws \Apiera\Sdk\Exception\Http\ApiException
-         * @throws \Apiera\Sdk\Exception\Mapping\MappingException
-         */
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
     public function create(RequestInterface $request): VariantResponse
     {
         if (!$request instanceof VariantRequest) {
@@ -127,11 +139,11 @@ final readonly class VariantResource implements RequestResourceInterface
         return $response;
     }
 
-        /**
-         * @throws InvalidRequestException
-         * @throws \Apiera\Sdk\Exception\Http\ApiException
-         * @throws \Apiera\Sdk\Exception\Mapping\MappingException
-         */
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
     public function update(RequestInterface $request): VariantResponse
     {
         if (!$request instanceof VariantRequest) {
@@ -154,10 +166,10 @@ final readonly class VariantResource implements RequestResourceInterface
         return $response;
     }
 
-        /**
-         * @throws InvalidRequestException
-         * @throws \Apiera\Sdk\Exception\Http\ApiException
-         */
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
     public function delete(RequestInterface $request): void
     {
         if (!$request instanceof VariantRequest) {


### PR DESCRIPTION

### Description
This pull request introduces `ResourceNotFoundException` and `MultipleResourcesFoundException` to replace the generic `InvalidRequestException` when querying resources. These new exceptions improve error clarity, aiding in precise error handling and debugging. Relevant resource classes have been updated to throw these specific exceptions based on query results.