### PR TITLE
Refactor resource interfaces for context distinction

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ $apieraConfig = new \Apiera\Sdk\Configuration(
     cache: $yourCacheInstance, // Pass a CacheItemPoolInterface object
     timeout: 15, // Optional: Request timeout (default: 10 seconds)
     debugMode: true, // Optional: Enable or disable debug mode (default: false)
-    options: [] // Optional: Pass your custom Guzzle handlers or middlewares
+    options: [], // Optional: Pass your custom Guzzle handlers or middlewares
+    defaultIntegration: 'integration-iri', // Optional: Pass a default integration iri reference
+    defaultInventoryLocation: 'inventory-location-iri', // Optional: Pass a default inventory location iri reference
+    defaultStore: 'store-iri' // Optional: Pass a default store iri reference
 );
 ```
 

--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -85,6 +85,7 @@ final readonly class ApieraSdk
         $this->resourceFactory = new ResourceFactory(
             new Client($this->configuration),
             new ReflectionAttributeDataMapper(),
+            $this->configuration,
         );
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -25,6 +25,9 @@ final readonly class Configuration implements ConfigurationInterface
      * @param string $oauthAudience Oauth2 audience
      * @param string $oauthOrganizationId OAuth2 organization ID.
      * @param array<string, mixed> $options
+     * @param string|null $defaultIntegration IRI reference
+     * @param string|null $defaultInventoryLocation IRI reference
+     * @param string|null $defaultStore IRI reference
      */
     public function __construct(
         private string $baseUrl,
@@ -39,6 +42,9 @@ final readonly class Configuration implements ConfigurationInterface
         private int $timeout = 10,
         private bool $debugMode = false,
         private array $options = [],
+        private ?string $defaultIntegration = null,
+        private ?string $defaultInventoryLocation = null,
+        private ?string $defaultStore = null,
     ) {
     }
 
@@ -103,5 +109,20 @@ final readonly class Configuration implements ConfigurationInterface
     public function getCache(): CacheItemPoolInterface
     {
         return $this->cache;
+    }
+
+    public function getDefaultIntegration(): ?string
+    {
+        return $this->defaultIntegration;
+    }
+
+    public function getDefaultInventoryLocation(): ?string
+    {
+        return $this->defaultInventoryLocation;
+    }
+
+    public function getDefaultStore(): ?string
+    {
+        return $this->defaultStore;
     }
 }

--- a/src/Factory/ResourceFactory.php
+++ b/src/Factory/ResourceFactory.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Apiera\Sdk\Factory;
 
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\RequestResourceInterface;
 
@@ -17,6 +19,7 @@ final readonly class ResourceFactory
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $dataMapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -29,6 +32,10 @@ final readonly class ResourceFactory
      */
     public function create(string $resourceClass): RequestResourceInterface
     {
+        if (is_subclass_of($resourceClass, ContextRequestResourceInterface::class)) {
+            return new $resourceClass($this->client, $this->dataMapper, $this->configuration);
+        }
+
         return new $resourceClass($this->client, $this->dataMapper);
     }
 }

--- a/src/Interface/ConfigurationInterface.php
+++ b/src/Interface/ConfigurationInterface.php
@@ -38,4 +38,10 @@ interface ConfigurationInterface
     public function getOptions(): array;
 
     public function getCache(): CacheItemPoolInterface;
+
+    public function getDefaultIntegration(): ?string;
+
+    public function getDefaultInventoryLocation(): ?string;
+
+    public function getDefaultStore(): ?string;
 }

--- a/src/Interface/ContextRequestResourceInterface.php
+++ b/src/Interface/ContextRequestResourceInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Interface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 2.0.0
+ */
+interface ContextRequestResourceInterface extends RequestResourceInterface
+{
+    public function __construct(
+        ClientInterface $client,
+        DataMapperInterface $dataMapper,
+        ConfigurationInterface $configuration
+    );
+}

--- a/src/Interface/NoContextRequestResourceInterface.php
+++ b/src/Interface/NoContextRequestResourceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Interface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 2.0.0
+ */
+interface NoContextRequestResourceInterface extends RequestResourceInterface
+{
+    public function __construct(ClientInterface $client, DataMapperInterface $dataMapper);
+}

--- a/src/Interface/RequestResourceInterface.php
+++ b/src/Interface/RequestResourceInterface.php
@@ -15,8 +15,6 @@ use Apiera\Sdk\Interface\DTO\ResponseInterface;
  */
 interface RequestResourceInterface
 {
-    public function __construct(ClientInterface $client, DataMapperInterface $dataMapper);
-
     public function find(RequestInterface $request, ?QueryParameters $params = null): JsonLDInterface;
 
     public function findOneBy(RequestInterface $request, QueryParameters $params): ResponseInterface;

--- a/src/Resource/AlternateIdentifierResource.php
+++ b/src/Resource/AlternateIdentifierResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 0.2.0
  */
-final readonly class AlternateIdentifierResource implements RequestResourceInterface
+final readonly class AlternateIdentifierResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/alternate_identifiers';
 

--- a/src/Resource/AttributeResource.php
+++ b/src/Resource/AttributeResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 0.2.0
  */
-final readonly class AttributeResource implements RequestResourceInterface
+final readonly class AttributeResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/attributes';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class AttributeResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var AttributeCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class AttributeResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class AttributeResource implements RequestResourceInterface
 
         /** @var AttributeResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/AttributeTermResource.php
+++ b/src/Resource/AttributeTermResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class AttributeTermResource implements RequestResourceInterface
+final readonly class AttributeTermResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/terms';
 

--- a/src/Resource/BrandResource.php
+++ b/src/Resource/BrandResource.php
@@ -12,22 +12,24 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
 use Apiera\Sdk\Interface\DTO\ResponseInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class BrandResource implements RequestResourceInterface
+final readonly class BrandResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/brands';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -46,13 +48,15 @@ final readonly class BrandResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var BrandCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -128,7 +132,9 @@ final readonly class BrandResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -136,7 +142,7 @@ final readonly class BrandResource implements RequestResourceInterface
 
         /** @var BrandResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/CategoryResource.php
+++ b/src/Resource/CategoryResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 0.1.0
  */
-final readonly class CategoryResource implements RequestResourceInterface
+final readonly class CategoryResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/categories';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class CategoryResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var CategoryCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class CategoryResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class CategoryResource implements RequestResourceInterface
 
         /** @var CategoryResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/DistributorResource.php
+++ b/src/Resource/DistributorResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class DistributorResource implements RequestResourceInterface
+final readonly class DistributorResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/distributors';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class DistributorResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var DistributorCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class DistributorResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class DistributorResource implements RequestResourceInterface
 
         /** @var DistributorResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/FileResource.php
+++ b/src/Resource/FileResource.php
@@ -15,13 +15,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class FileResource implements RequestResourceInterface
+final readonly class FileResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/files';
 

--- a/src/Resource/InventoryLocationResource.php
+++ b/src/Resource/InventoryLocationResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class InventoryLocationResource implements RequestResourceInterface
+final readonly class InventoryLocationResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/inventory_locations';
 

--- a/src/Resource/InventoryResource.php
+++ b/src/Resource/InventoryResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**int
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class InventoryResource implements RequestResourceInterface
+final readonly class InventoryResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/inventories';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class InventoryResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getInventoryLocation()) {
+        $inventoryLocation = $request->getInventoryLocation() ?? $this->configuration->getDefaultInventoryLocation();
+
+        if ($inventoryLocation === null) {
             throw new InvalidRequestException('Inventory location IRI is required for this operation');
         }
 
         /** @var InventoryCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getInventoryLocation() . self::ENDPOINT, $params)
+            $this->client->get($inventoryLocation . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class InventoryResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getInventoryLocation()) {
+        $inventoryLocation = $request->getInventoryLocation() ?? $this->configuration->getDefaultInventoryLocation();
+
+        if ($inventoryLocation === null) {
             throw new InvalidRequestException('Inventory location IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class InventoryResource implements RequestResourceInterface
 
         /** @var InventoryResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getInventoryLocation() . self::ENDPOINT, $requestData)
+            $this->client->post($inventoryLocation . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/OrganizationResource.php
+++ b/src/Resource/OrganizationResource.php
@@ -15,13 +15,13 @@ use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
 use Apiera\Sdk\Interface\DTO\ResponseInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class OrganizationResource implements RequestResourceInterface
+final readonly class OrganizationResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/organizations';
 

--- a/src/Resource/ProductResource.php
+++ b/src/Resource/ProductResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class ProductResource implements RequestResourceInterface
+final readonly class ProductResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/products';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class ProductResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var ProductCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class ProductResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class ProductResource implements RequestResourceInterface
 
         /** @var ProductResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/PropertyResource.php
+++ b/src/Resource/PropertyResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class PropertyResource implements RequestResourceInterface
+final readonly class PropertyResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/properties';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class PropertyResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var PropertyCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class PropertyResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class PropertyResource implements RequestResourceInterface
 
         /** @var PropertyResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/PropertyTermResource.php
+++ b/src/Resource/PropertyTermResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class PropertyTermResource implements RequestResourceInterface
+final readonly class PropertyTermResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/terms';
 

--- a/src/Resource/ResourceMapResource.php
+++ b/src/Resource/ResourceMapResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class ResourceMapResource implements RequestResourceInterface
+final readonly class ResourceMapResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/mappings';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class ResourceMapResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getIntegration()) {
+        $integration = $request->getIntegration() ?? $this->configuration->getDefaultIntegration();
+
+        if ($integration === null) {
             throw new InvalidRequestException('Integration IRI is required for this operation');
         }
 
         /** @var ResourceMapCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getIntegration() . self::ENDPOINT, $params)
+            $this->client->get($integration . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class ResourceMapResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getIntegration()) {
+        $integration = $request->getIntegration() ?? $this->configuration->getDefaultIntegration();
+
+        if ($integration === null) {
             throw new InvalidRequestException('Integration IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class ResourceMapResource implements RequestResourceInterface
 
         /** @var ResourceMapResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getIntegration() . self::ENDPOINT, $requestData)
+            $this->client->post($integration . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/SkuResource.php
+++ b/src/Resource/SkuResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class SkuResource implements RequestResourceInterface
+final readonly class SkuResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/skus';
 

--- a/src/Resource/StoreResource.php
+++ b/src/Resource/StoreResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class StoreResource implements RequestResourceInterface
+final readonly class StoreResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/stores';
 

--- a/src/Resource/TagResource.php
+++ b/src/Resource/TagResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnoge.no>
  * @since 1.0.0
  */
-final readonly class TagResource implements RequestResourceInterface
+final readonly class TagResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/tags';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class TagResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var TagCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class TagResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class TagResource implements RequestResourceInterface
 
         /** @var TagResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/VariantResource.php
+++ b/src/Resource/VariantResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class VariantResource implements RequestResourceInterface
+final readonly class VariantResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/variants';
 


### PR DESCRIPTION
### Description

This pull request refactors the resource handling interfaces to introduce `ContextRequestResourceInterface` and `NoContextRequestResourceInterface`, replacing the previously used `RequestResourceInterface`. This change allows for clear differentiation between resources requiring context configuration and those that do not.

Additionally:

- Added default context fallback logic for stores, integration, and inventory locations in applicable resources.
- Updated the `Configuration` class and `ResourceFactory` to support these new interface structures.
  
The refactor enhances flexibility and improves clarity in resource management across the application.