### PR TITLE
Make `ldFirst` and `ldLast` nullable in `PartialCollectionView`

### DIFF
--- a/src/DTO/Response/PartialCollectionView.php
+++ b/src/DTO/Response/PartialCollectionView.php
@@ -8,8 +8,8 @@ final readonly class PartialCollectionView
 {
     public function __construct(
         private string $ldId,
-        private string $ldFirst,
-        private string $ldLast,
+        private ?string $ldFirst = null,
+        private ?string $ldLast = null,
         private ?string $ldNext = null,
         private ?string $ldPrevious = null,
     ) {
@@ -20,12 +20,12 @@ final readonly class PartialCollectionView
         return $this->ldId;
     }
 
-    public function getLdFirst(): string
+    public function getLdFirst(): ?string
     {
         return $this->ldFirst;
     }
 
-    public function getLdLast(): string
+    public function getLdLast(): ?string
     {
         return $this->ldLast;
     }

--- a/src/DataMapper/ReflectionAttributeDataMapper.php
+++ b/src/DataMapper/ReflectionAttributeDataMapper.php
@@ -87,8 +87,8 @@ final class ReflectionAttributeDataMapper implements DataMapperInterface
                 ldTotalItems: $collectionResponseData['totalItems'],
                 ldView: isset($collectionResponseData['view']) ? new PartialCollectionView(
                     ldId: $collectionResponseData['view']['@id'],
-                    ldFirst: $collectionResponseData['view']['first'],
-                    ldLast: $collectionResponseData['view']['last'],
+                    ldFirst: $collectionResponseData['view']['first'] ?? null,
+                    ldLast: $collectionResponseData['view']['last'] ?? null,
                     ldNext: $collectionResponseData['view']['next'] ?? null,
                     ldPrevious: $collectionResponseData['view']['previous'] ?? null,
                 ) : null,


### PR DESCRIPTION
### Description

This updates the `PartialCollectionView` to make the `ldFirst` and `ldLast` properties nullable. The change ensures compatibility with scenarios where these values may not be present in the response. Adjustments include adding default values and refining type hints to align with the nullable properties.