### PR TITLE
Make ldFirst and ldLast nullable, refactor resources, and enhance exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ $apieraConfig = new \Apiera\Sdk\Configuration(
     cache: $yourCacheInstance, // Pass a CacheItemPoolInterface object
     timeout: 15, // Optional: Request timeout (default: 10 seconds)
     debugMode: true, // Optional: Enable or disable debug mode (default: false)
-    options: [] // Optional: Pass your custom Guzzle handlers or middlewares
+    options: [], // Optional: Pass your custom Guzzle handlers or middlewares
+    defaultIntegration: 'integration-iri', // Optional: Pass a default integration iri reference
+    defaultInventoryLocation: 'inventory-location-iri', // Optional: Pass a default inventory location iri reference
+    defaultStore: 'store-iri' // Optional: Pass a default store iri reference
 );
 ```
 

--- a/src/ApieraSdk.php
+++ b/src/ApieraSdk.php
@@ -85,6 +85,7 @@ final readonly class ApieraSdk
         $this->resourceFactory = new ResourceFactory(
             new Client($this->configuration),
             new ReflectionAttributeDataMapper(),
+            $this->configuration,
         );
     }
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -25,6 +25,9 @@ final readonly class Configuration implements ConfigurationInterface
      * @param string $oauthAudience Oauth2 audience
      * @param string $oauthOrganizationId OAuth2 organization ID.
      * @param array<string, mixed> $options
+     * @param string|null $defaultIntegration IRI reference
+     * @param string|null $defaultInventoryLocation IRI reference
+     * @param string|null $defaultStore IRI reference
      */
     public function __construct(
         private string $baseUrl,
@@ -39,6 +42,9 @@ final readonly class Configuration implements ConfigurationInterface
         private int $timeout = 10,
         private bool $debugMode = false,
         private array $options = [],
+        private ?string $defaultIntegration = null,
+        private ?string $defaultInventoryLocation = null,
+        private ?string $defaultStore = null,
     ) {
     }
 
@@ -103,5 +109,20 @@ final readonly class Configuration implements ConfigurationInterface
     public function getCache(): CacheItemPoolInterface
     {
         return $this->cache;
+    }
+
+    public function getDefaultIntegration(): ?string
+    {
+        return $this->defaultIntegration;
+    }
+
+    public function getDefaultInventoryLocation(): ?string
+    {
+        return $this->defaultInventoryLocation;
+    }
+
+    public function getDefaultStore(): ?string
+    {
+        return $this->defaultStore;
     }
 }

--- a/src/DTO/Response/PartialCollectionView.php
+++ b/src/DTO/Response/PartialCollectionView.php
@@ -8,8 +8,8 @@ final readonly class PartialCollectionView
 {
     public function __construct(
         private string $ldId,
-        private string $ldFirst,
-        private string $ldLast,
+        private ?string $ldFirst = null,
+        private ?string $ldLast = null,
         private ?string $ldNext = null,
         private ?string $ldPrevious = null,
     ) {
@@ -20,12 +20,12 @@ final readonly class PartialCollectionView
         return $this->ldId;
     }
 
-    public function getLdFirst(): string
+    public function getLdFirst(): ?string
     {
         return $this->ldFirst;
     }
 
-    public function getLdLast(): string
+    public function getLdLast(): ?string
     {
         return $this->ldLast;
     }

--- a/src/DataMapper/ReflectionAttributeDataMapper.php
+++ b/src/DataMapper/ReflectionAttributeDataMapper.php
@@ -87,8 +87,8 @@ final class ReflectionAttributeDataMapper implements DataMapperInterface
                 ldTotalItems: $collectionResponseData['totalItems'],
                 ldView: isset($collectionResponseData['view']) ? new PartialCollectionView(
                     ldId: $collectionResponseData['view']['@id'],
-                    ldFirst: $collectionResponseData['view']['first'],
-                    ldLast: $collectionResponseData['view']['last'],
+                    ldFirst: $collectionResponseData['view']['first'] ?? null,
+                    ldLast: $collectionResponseData['view']['last'] ?? null,
                     ldNext: $collectionResponseData['view']['next'] ?? null,
                     ldPrevious: $collectionResponseData['view']['previous'] ?? null,
                 ) : null,

--- a/src/Exception/MultipleResourcesFoundException.php
+++ b/src/Exception/MultipleResourcesFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Exception;
+
+use Exception;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 2.0.0
+ */
+final class MultipleResourcesFoundException extends Exception
+{
+}

--- a/src/Exception/ResourceNotFoundException.php
+++ b/src/Exception/ResourceNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Exception;
+
+use Exception;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 2.0.0
+ */
+final class ResourceNotFoundException extends Exception
+{
+}

--- a/src/Factory/ResourceFactory.php
+++ b/src/Factory/ResourceFactory.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Apiera\Sdk\Factory;
 
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\RequestResourceInterface;
 
@@ -17,6 +19,7 @@ final readonly class ResourceFactory
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $dataMapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -29,6 +32,10 @@ final readonly class ResourceFactory
      */
     public function create(string $resourceClass): RequestResourceInterface
     {
+        if (is_subclass_of($resourceClass, ContextRequestResourceInterface::class)) {
+            return new $resourceClass($this->client, $this->dataMapper, $this->configuration);
+        }
+
         return new $resourceClass($this->client, $this->dataMapper);
     }
 }

--- a/src/Interface/ConfigurationInterface.php
+++ b/src/Interface/ConfigurationInterface.php
@@ -38,4 +38,10 @@ interface ConfigurationInterface
     public function getOptions(): array;
 
     public function getCache(): CacheItemPoolInterface;
+
+    public function getDefaultIntegration(): ?string;
+
+    public function getDefaultInventoryLocation(): ?string;
+
+    public function getDefaultStore(): ?string;
 }

--- a/src/Interface/ContextRequestResourceInterface.php
+++ b/src/Interface/ContextRequestResourceInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Interface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 2.0.0
+ */
+interface ContextRequestResourceInterface extends RequestResourceInterface
+{
+    public function __construct(
+        ClientInterface $client,
+        DataMapperInterface $dataMapper,
+        ConfigurationInterface $configuration
+    );
+}

--- a/src/Interface/NoContextRequestResourceInterface.php
+++ b/src/Interface/NoContextRequestResourceInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Apiera\Sdk\Interface;
+
+/**
+ * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
+ * @since 2.0.0
+ */
+interface NoContextRequestResourceInterface extends RequestResourceInterface
+{
+    public function __construct(ClientInterface $client, DataMapperInterface $dataMapper);
+}

--- a/src/Interface/RequestResourceInterface.php
+++ b/src/Interface/RequestResourceInterface.php
@@ -15,8 +15,6 @@ use Apiera\Sdk\Interface\DTO\ResponseInterface;
  */
 interface RequestResourceInterface
 {
-    public function __construct(ClientInterface $client, DataMapperInterface $dataMapper);
-
     public function find(RequestInterface $request, ?QueryParameters $params = null): JsonLDInterface;
 
     public function findOneBy(RequestInterface $request, QueryParameters $params): ResponseInterface;

--- a/src/Resource/AlternateIdentifierResource.php
+++ b/src/Resource/AlternateIdentifierResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 0.2.0
  */
-final readonly class AlternateIdentifierResource implements RequestResourceInterface
+final readonly class AlternateIdentifierResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/alternate_identifiers';
 

--- a/src/Resource/AlternateIdentifierResource.php
+++ b/src/Resource/AlternateIdentifierResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\AlternateIdentifier\AlternateIdentifierRequest;
 use Apiera\Sdk\DTO\Response\AlternateIdentifier\AlternateIdentifierCollectionResponse;
 use Apiera\Sdk\DTO\Response\AlternateIdentifier\AlternateIdentifierResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -53,6 +55,8 @@ final readonly class AlternateIdentifierResource implements RequestResourceInter
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -67,7 +71,15 @@ final readonly class AlternateIdentifierResource implements RequestResourceInter
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No alternate identifier found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No alternate identifier found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple alternate identifiers found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/AttributeResource.php
+++ b/src/Resource/AttributeResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 0.2.0
  */
-final readonly class AttributeResource implements RequestResourceInterface
+final readonly class AttributeResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/attributes';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class AttributeResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var AttributeCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class AttributeResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class AttributeResource implements RequestResourceInterface
 
         /** @var AttributeResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/AttributeResource.php
+++ b/src/Resource/AttributeResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Attribute\AttributeRequest;
 use Apiera\Sdk\DTO\Response\Attribute\AttributeCollectionResponse;
 use Apiera\Sdk\DTO\Response\Attribute\AttributeResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class AttributeResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class AttributeResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No attribute found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No attribute found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple attributes found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/AttributeTermResource.php
+++ b/src/Resource/AttributeTermResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class AttributeTermResource implements RequestResourceInterface
+final readonly class AttributeTermResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/terms';
 

--- a/src/Resource/AttributeTermResource.php
+++ b/src/Resource/AttributeTermResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\AttributeTerm\AttributeTermRequest;
 use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermCollectionResponse;
 use Apiera\Sdk\DTO\Response\AttributeTerm\AttributeTermResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class AttributeTermResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class AttributeTermResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No attribute term found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No attribute term found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple attribute terms found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/BrandResource.php
+++ b/src/Resource/BrandResource.php
@@ -12,22 +12,24 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
 use Apiera\Sdk\Interface\DTO\ResponseInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class BrandResource implements RequestResourceInterface
+final readonly class BrandResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/brands';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -46,13 +48,15 @@ final readonly class BrandResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var BrandCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -128,7 +132,9 @@ final readonly class BrandResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -136,7 +142,7 @@ final readonly class BrandResource implements RequestResourceInterface
 
         /** @var BrandResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/BrandResource.php
+++ b/src/Resource/BrandResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Brand\BrandRequest;
 use Apiera\Sdk\DTO\Response\Brand\BrandCollectionResponse;
 use Apiera\Sdk\DTO\Response\Brand\BrandResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -58,6 +60,8 @@ final readonly class BrandResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -72,7 +76,15 @@ final readonly class BrandResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No brand found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No brand found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple brands found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/CategoryResource.php
+++ b/src/Resource/CategoryResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Category\CategoryRequest;
 use Apiera\Sdk\DTO\Response\Category\CategoryCollectionResponse;
 use Apiera\Sdk\DTO\Response\Category\CategoryResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class CategoryResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class CategoryResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No category found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No category found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple categories found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/CategoryResource.php
+++ b/src/Resource/CategoryResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 0.1.0
  */
-final readonly class CategoryResource implements RequestResourceInterface
+final readonly class CategoryResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/categories';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class CategoryResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var CategoryCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class CategoryResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class CategoryResource implements RequestResourceInterface
 
         /** @var CategoryResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/DistributorResource.php
+++ b/src/Resource/DistributorResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Distributor\DistributorRequest;
 use Apiera\Sdk\DTO\Response\Distributor\DistributorCollectionResponse;
 use Apiera\Sdk\DTO\Response\Distributor\DistributorResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class DistributorResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class DistributorResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No distributor found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No distributor found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple distributors found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/DistributorResource.php
+++ b/src/Resource/DistributorResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class DistributorResource implements RequestResourceInterface
+final readonly class DistributorResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/distributors';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class DistributorResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var DistributorCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class DistributorResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class DistributorResource implements RequestResourceInterface
 
         /** @var DistributorResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/FileResource.php
+++ b/src/Resource/FileResource.php
@@ -15,13 +15,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class FileResource implements RequestResourceInterface
+final readonly class FileResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/files';
 

--- a/src/Resource/FileResource.php
+++ b/src/Resource/FileResource.php
@@ -9,7 +9,9 @@ use Apiera\Sdk\DTO\Request\File\FileRequest;
 use Apiera\Sdk\DTO\Response\File\FileCollectionResponse;
 use Apiera\Sdk\DTO\Response\File\FileResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\NotSupportedOperationException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -52,6 +54,8 @@ final readonly class FileResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -66,7 +70,15 @@ final readonly class FileResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No file found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No file found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple files found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/InventoryLocationResource.php
+++ b/src/Resource/InventoryLocationResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class InventoryLocationResource implements RequestResourceInterface
+final readonly class InventoryLocationResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/inventory_locations';
 

--- a/src/Resource/InventoryLocationResource.php
+++ b/src/Resource/InventoryLocationResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\InventoryLocation\InventoryLocationRequest;
 use Apiera\Sdk\DTO\Response\InventoryLocation\InventoryLocationCollectionResponse;
 use Apiera\Sdk\DTO\Response\InventoryLocation\InventoryLocationResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -53,6 +55,8 @@ final readonly class InventoryLocationResource implements RequestResourceInterfa
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -67,7 +71,15 @@ final readonly class InventoryLocationResource implements RequestResourceInterfa
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No inventory location found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No inventory location found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple inventory locations found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/InventoryResource.php
+++ b/src/Resource/InventoryResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**int
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class InventoryResource implements RequestResourceInterface
+final readonly class InventoryResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/inventories';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class InventoryResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getInventoryLocation()) {
+        $inventoryLocation = $request->getInventoryLocation() ?? $this->configuration->getDefaultInventoryLocation();
+
+        if ($inventoryLocation === null) {
             throw new InvalidRequestException('Inventory location IRI is required for this operation');
         }
 
         /** @var InventoryCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getInventoryLocation() . self::ENDPOINT, $params)
+            $this->client->get($inventoryLocation . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class InventoryResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getInventoryLocation()) {
+        $inventoryLocation = $request->getInventoryLocation() ?? $this->configuration->getDefaultInventoryLocation();
+
+        if ($inventoryLocation === null) {
             throw new InvalidRequestException('Inventory location IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class InventoryResource implements RequestResourceInterface
 
         /** @var InventoryResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getInventoryLocation() . self::ENDPOINT, $requestData)
+            $this->client->post($inventoryLocation . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/InventoryResource.php
+++ b/src/Resource/InventoryResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Inventory\InventoryRequest;
 use Apiera\Sdk\DTO\Response\Inventory\InventoryCollectionResponse;
 use Apiera\Sdk\DTO\Response\Inventory\InventoryResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class InventoryResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class InventoryResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No inventory found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No inventory found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple inventories found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/OrganizationResource.php
+++ b/src/Resource/OrganizationResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Organization\OrganizationRequest;
 use Apiera\Sdk\DTO\Response\Organization\OrganizationCollectionResponse;
 use Apiera\Sdk\DTO\Response\Organization\OrganizationResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -52,6 +54,8 @@ final readonly class OrganizationResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -66,7 +70,15 @@ final readonly class OrganizationResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No organization found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No organization found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple organizations found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/OrganizationResource.php
+++ b/src/Resource/OrganizationResource.php
@@ -15,13 +15,13 @@ use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
 use Apiera\Sdk\Interface\DTO\ResponseInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class OrganizationResource implements RequestResourceInterface
+final readonly class OrganizationResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/organizations';
 

--- a/src/Resource/ProductResource.php
+++ b/src/Resource/ProductResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Product\ProductRequest;
 use Apiera\Sdk\DTO\Response\Product\ProductCollectionResponse;
 use Apiera\Sdk\DTO\Response\Product\ProductResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class ProductResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class ProductResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No product found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No product found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple products found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/ProductResource.php
+++ b/src/Resource/ProductResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class ProductResource implements RequestResourceInterface
+final readonly class ProductResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/products';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class ProductResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var ProductCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class ProductResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class ProductResource implements RequestResourceInterface
 
         /** @var ProductResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/PropertyResource.php
+++ b/src/Resource/PropertyResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Property\PropertyRequest;
 use Apiera\Sdk\DTO\Response\Property\PropertyCollectionResponse;
 use Apiera\Sdk\DTO\Response\Property\PropertyResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class PropertyResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class PropertyResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No property found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No property found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple properties found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/PropertyResource.php
+++ b/src/Resource/PropertyResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class PropertyResource implements RequestResourceInterface
+final readonly class PropertyResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/properties';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class PropertyResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var PropertyCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class PropertyResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class PropertyResource implements RequestResourceInterface
 
         /** @var PropertyResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/PropertyTermResource.php
+++ b/src/Resource/PropertyTermResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\PropertyTerm\PropertyTermRequest;
 use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermCollectionResponse;
 use Apiera\Sdk\DTO\Response\PropertyTerm\PropertyTermResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class PropertyTermResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class PropertyTermResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No property term found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No property term found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple property terms found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/PropertyTermResource.php
+++ b/src/Resource/PropertyTermResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class PropertyTermResource implements RequestResourceInterface
+final readonly class PropertyTermResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/terms';
 

--- a/src/Resource/ResourceMapResource.php
+++ b/src/Resource/ResourceMapResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Fredrik Tveraaen <fredrik.tveraaen@apiera.io>
  * @since 1.0.0
  */
-final readonly class ResourceMapResource implements RequestResourceInterface
+final readonly class ResourceMapResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/mappings';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class ResourceMapResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getIntegration()) {
+        $integration = $request->getIntegration() ?? $this->configuration->getDefaultIntegration();
+
+        if ($integration === null) {
             throw new InvalidRequestException('Integration IRI is required for this operation');
         }
 
         /** @var ResourceMapCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getIntegration() . self::ENDPOINT, $params)
+            $this->client->get($integration . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class ResourceMapResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getIntegration()) {
+        $integration = $request->getIntegration() ?? $this->configuration->getDefaultIntegration();
+
+        if ($integration === null) {
             throw new InvalidRequestException('Integration IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class ResourceMapResource implements RequestResourceInterface
 
         /** @var ResourceMapResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getIntegration() . self::ENDPOINT, $requestData)
+            $this->client->post($integration . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/ResourceMapResource.php
+++ b/src/Resource/ResourceMapResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\ResourceMap\ResourceMapRequest;
 use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapCollectionResponse;
 use Apiera\Sdk\DTO\Response\ResourceMap\ResourceMapResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class ResourceMapResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class ResourceMapResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No resource map found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No resource map found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple resource maps found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/SkuResource.php
+++ b/src/Resource/SkuResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class SkuResource implements RequestResourceInterface
+final readonly class SkuResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/skus';
 

--- a/src/Resource/SkuResource.php
+++ b/src/Resource/SkuResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Sku\SkuRequest;
 use Apiera\Sdk\DTO\Response\Sku\SkuCollectionResponse;
 use Apiera\Sdk\DTO\Response\Sku\SkuResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -51,6 +53,8 @@ final readonly class SkuResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -65,7 +69,15 @@ final readonly class SkuResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No sku found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No sku found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple skus found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/StoreResource.php
+++ b/src/Resource/StoreResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class StoreResource implements RequestResourceInterface
+final readonly class StoreResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/api/v1/stores';
 

--- a/src/Resource/StoreResource.php
+++ b/src/Resource/StoreResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Store\StoreRequest;
 use Apiera\Sdk\DTO\Response\Store\StoreCollectionResponse;
 use Apiera\Sdk\DTO\Response\Store\StoreResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -51,6 +53,8 @@ final readonly class StoreResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -65,7 +69,15 @@ final readonly class StoreResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No store found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No store found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple stores found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/TagResource.php
+++ b/src/Resource/TagResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Tag\TagRequest;
 use Apiera\Sdk\DTO\Response\Tag\TagCollectionResponse;
 use Apiera\Sdk\DTO\Response\Tag\TagResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class TagResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,7 +73,15 @@ final readonly class TagResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No tag found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No tag found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple tags found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];

--- a/src/Resource/TagResource.php
+++ b/src/Resource/TagResource.php
@@ -12,21 +12,23 @@ use Apiera\Sdk\Exception\InvalidRequestException;
 use Apiera\Sdk\Exception\MultipleResourcesFoundException;
 use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
+use Apiera\Sdk\Interface\ConfigurationInterface;
+use Apiera\Sdk\Interface\ContextRequestResourceInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnoge.no>
  * @since 1.0.0
  */
-final readonly class TagResource implements RequestResourceInterface
+final readonly class TagResource implements ContextRequestResourceInterface
 {
     private const string ENDPOINT = '/tags';
 
     public function __construct(
         private ClientInterface $client,
         private DataMapperInterface $mapper,
+        private ConfigurationInterface $configuration,
     ) {
     }
 
@@ -43,13 +45,15 @@ final readonly class TagResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
         /** @var TagCollectionResponse $collectionResponse */
         $collectionResponse = $this->mapper->fromCollectionResponse($this->client->decodeResponse(
-            $this->client->get($request->getStore() . self::ENDPOINT, $params)
+            $this->client->get($store . self::ENDPOINT, $params)
         ));
 
         return $collectionResponse;
@@ -125,7 +129,9 @@ final readonly class TagResource implements RequestResourceInterface
             );
         }
 
-        if (!$request->getStore()) {
+        $store = $request->getStore() ?? $this->configuration->getDefaultStore();
+
+        if ($store === null) {
             throw new InvalidRequestException('Store IRI is required for this operation');
         }
 
@@ -133,7 +139,7 @@ final readonly class TagResource implements RequestResourceInterface
 
         /** @var TagResponse $response */
         $response = $this->mapper->fromResponse($this->client->decodeResponse(
-            $this->client->post($request->getStore() . self::ENDPOINT, $requestData)
+            $this->client->post($store . self::ENDPOINT, $requestData)
         ));
 
         return $response;

--- a/src/Resource/VariantResource.php
+++ b/src/Resource/VariantResource.php
@@ -9,6 +9,8 @@ use Apiera\Sdk\DTO\Request\Variant\VariantRequest;
 use Apiera\Sdk\DTO\Response\Variant\VariantCollectionResponse;
 use Apiera\Sdk\DTO\Response\Variant\VariantResponse;
 use Apiera\Sdk\Exception\InvalidRequestException;
+use Apiera\Sdk\Exception\MultipleResourcesFoundException;
+use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
@@ -55,6 +57,8 @@ final readonly class VariantResource implements RequestResourceInterface
 
     /**
      * @throws InvalidRequestException
+     * @throws ResourceNotFoundException
+     * @throws MultipleResourcesFoundException
      * @throws \Apiera\Sdk\Exception\Http\ApiException
      * @throws \Apiera\Sdk\Exception\Mapping\MappingException
      */
@@ -69,17 +73,25 @@ final readonly class VariantResource implements RequestResourceInterface
         $collection = $this->find($request, $params);
 
         if ($collection->getLdTotalItems() < 1) {
-            throw new InvalidRequestException('No variant found matching the given criteria');
+            throw new ResourceNotFoundException(
+                'No variant found matching the given criteria'
+            );
+        }
+
+        if ($collection->getLdTotalItems() > 1) {
+            throw new MultipleResourcesFoundException(
+                'Multiple variants found matching the given criteria'
+            );
         }
 
         return $collection->getLdMembers()[0];
     }
 
-        /**
-         * @throws InvalidRequestException
-         * @throws \Apiera\Sdk\Exception\Http\ApiException
-         * @throws \Apiera\Sdk\Exception\Mapping\MappingException
-         */
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
     public function get(RequestInterface $request): VariantResponse
     {
         if (!$request instanceof VariantRequest) {
@@ -100,11 +112,11 @@ final readonly class VariantResource implements RequestResourceInterface
         return $response;
     }
 
-        /**
-         * @throws InvalidRequestException
-         * @throws \Apiera\Sdk\Exception\Http\ApiException
-         * @throws \Apiera\Sdk\Exception\Mapping\MappingException
-         */
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
     public function create(RequestInterface $request): VariantResponse
     {
         if (!$request instanceof VariantRequest) {
@@ -127,11 +139,11 @@ final readonly class VariantResource implements RequestResourceInterface
         return $response;
     }
 
-        /**
-         * @throws InvalidRequestException
-         * @throws \Apiera\Sdk\Exception\Http\ApiException
-         * @throws \Apiera\Sdk\Exception\Mapping\MappingException
-         */
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     * @throws \Apiera\Sdk\Exception\Mapping\MappingException
+     */
     public function update(RequestInterface $request): VariantResponse
     {
         if (!$request instanceof VariantRequest) {
@@ -154,10 +166,10 @@ final readonly class VariantResource implements RequestResourceInterface
         return $response;
     }
 
-        /**
-         * @throws InvalidRequestException
-         * @throws \Apiera\Sdk\Exception\Http\ApiException
-         */
+    /**
+     * @throws InvalidRequestException
+     * @throws \Apiera\Sdk\Exception\Http\ApiException
+     */
     public function delete(RequestInterface $request): void
     {
         if (!$request instanceof VariantRequest) {

--- a/src/Resource/VariantResource.php
+++ b/src/Resource/VariantResource.php
@@ -14,13 +14,13 @@ use Apiera\Sdk\Exception\ResourceNotFoundException;
 use Apiera\Sdk\Interface\ClientInterface;
 use Apiera\Sdk\Interface\DataMapperInterface;
 use Apiera\Sdk\Interface\DTO\RequestInterface;
-use Apiera\Sdk\Interface\RequestResourceInterface;
+use Apiera\Sdk\Interface\NoContextRequestResourceInterface;
 
 /**
  * @author Marie Rinden <marie@shoppingnorge.no>
  * @since 1.0.0
  */
-final readonly class VariantResource implements RequestResourceInterface
+final readonly class VariantResource implements NoContextRequestResourceInterface
 {
     private const string ENDPOINT = '/variants';
 


### PR DESCRIPTION
### Summary

This pull request introduces several changes to improve code flexibility, error handling, and compatibility:

1. **Make `ldFirst` and `ldLast` Nullable in `PartialCollectionView`**  
   Updates to `PartialCollectionView` and its usages allow `ldFirst` and `ldLast` to handle cases where these values may be absent in response data. This change includes adjustments to default values and type hints.

2. **Refactor Resource Interfaces**  
   Introduces `ContextRequestResourceInterface` and `NoContextRequestResourceInterface`, replacing `RequestResourceInterface`. Provides better differentiation between resources requiring context configuration and those that do not. Improvements include default context fallback logic and updates to `Configuration` and `ResourceFactory`.

3. **Add Specific Exceptions for Resource Query Outcomes**  
   Adds `ResourceNotFoundException` and `MultipleResourcesFoundException` to replace the use of the generic `InvalidRequestException` for resource queries. This ensures more precise error identification and improved debugging.